### PR TITLE
Add shutdown signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,10 +1450,9 @@ name = "inspector-protocol-subscriber"
 version = "0.1.0"
 dependencies = [
  "inspector-protocol-primitives",
- "serde",
- "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "tracing-core",
  "tracing-subscriber",
 ]

--- a/examples/tauri/Cargo.lock
+++ b/examples/tauri/Cargo.lock
@@ -1455,10 +1455,9 @@ name = "inspector-protocol-subscriber"
 version = "0.1.0"
 dependencies = [
  "inspector-protocol-primitives",
- "serde",
- "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "tracing-core",
  "tracing-subscriber",
 ]

--- a/subscriber/Cargo.toml
+++ b/subscriber/Cargo.toml
@@ -19,7 +19,6 @@ homepage.workspace = true
 tokio = { workspace = true, features = ["macros", "time"] }
 tracing-subscriber.workspace = true
 tracing-core.workspace = true
+tracing.workspace = true
 inspector-protocol-primitives.workspace = true
-serde_json.workspace = true
-serde.workspace = true
 thiserror.workspace = true

--- a/subscriber/src/dispatch/mod.rs
+++ b/subscriber/src/dispatch/mod.rs
@@ -1,5 +1,5 @@
-pub use broadcast::BroadcastConfig;
 use broadcast::Broadcaster;
+pub use broadcast::{BroadcastConfig, BroadcastConfigBuilder};
 use inspector_protocol_primitives::Tree;
 use tokio::sync::mpsc;
 
@@ -55,11 +55,9 @@ impl<'a: 'static> BroadcastDispatcher<'a> {
 	/// or on a specified Tokio handle provided in the `config`.
 	pub(crate) fn new(config: BroadcastConfig<'a>) -> Self {
 		let (out, rx) = mpsc::unbounded_channel();
-		let future = Broadcaster::new(config.clone()).run(rx);
-
 		match config.tokio_handle().as_ref() {
-			Some(tokio_handle) => tokio_handle.spawn(future),
-			None => tokio::spawn(future),
+			Some(tokio_handle) => tokio_handle.spawn(Broadcaster::new(config).run(rx)),
+			None => tokio::spawn(Broadcaster::new(config).run(rx)),
 		};
 
 		Self { out }

--- a/subscriber/src/layer/event_visitor.rs
+++ b/subscriber/src/layer/event_visitor.rs
@@ -1,6 +1,7 @@
 use inspector_protocol_primitives::{Field as InspectorFied, FieldSet};
 use std::fmt;
 use tracing_core::Field;
+use tracing_subscriber::field::Visit;
 
 /// Represents an event visitor that collects information about tracing events.
 #[derive(Default)]
@@ -11,7 +12,7 @@ pub(crate) struct EventVisitor {
 	pub(crate) fields: FieldSet,
 }
 
-impl tracing_subscriber::field::Visit for EventVisitor {
+impl Visit for EventVisitor {
 	/// Visit a string value.
 	fn record_str(&mut self, field: &Field, value: &str) {
 		match field.name() {

--- a/subscriber/src/lib.rs
+++ b/subscriber/src/lib.rs
@@ -19,7 +19,7 @@
 //! using a Tokio channel. Designed with real-time data streaming in mind, it can be coupled with
 //! a WebSocket RPC server, allowing clients to receive and react to tracing events in real-time.
 //!
-pub use dispatch::{BroadcastConfig, BroadcastDispatcher, Dispatcher, NoopDispatcher};
+pub use dispatch::{BroadcastConfig, BroadcastConfigBuilder, BroadcastDispatcher, Dispatcher, NoopDispatcher};
 pub use error::{Error, Result};
 pub use layer::Layer;
 pub use subscriber::{Subscriber, SubscriberBuilder};

--- a/subscriber/src/subscriber.rs
+++ b/subscriber/src/subscriber.rs
@@ -1,6 +1,7 @@
-use crate::dispatch::{Dispatcher, NoopDispatcher};
-use crate::Layer;
-use crate::Result;
+use crate::{
+	dispatch::{Dispatcher, NoopDispatcher},
+	Layer, Result,
+};
 use std::any::TypeId;
 use tracing_core::{span, Event, Interest, LevelFilter, Metadata};
 use tracing_subscriber::registry::LookupSpan;


### PR DESCRIPTION
Connected to the `RunEvent::Exit`, a signal is sent to the subscriber to flush the queue immediately.

Fixes DR-330