### PR TITLE
feat: add probes crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 
 target
+
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2177,6 +2177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "probes"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+ "tracing",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,9 +2228,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -2528,7 +2538,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2550,7 +2560,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2588,7 +2598,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2797,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3132,7 +3142,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3214,7 +3224,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3331,7 +3341,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3524,7 +3534,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -3546,7 +3556,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "subscriber",
     "primitives",
     "plugins/tauri",
+    "probes",
 ]
 
 exclude = [

--- a/probes/Cargo.toml
+++ b/probes/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "probes"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proc-macro2 = "1.0.67"
+quote = "1.0.33"
+syn = "2.0.37"
+tracing.workspace = true

--- a/probes/src/args.rs
+++ b/probes/src/args.rs
@@ -1,0 +1,61 @@
+//! The shared argument type for all macros
+//!
+//! Just a fancy parsing wrapper around `{ ident: expr }`
+
+use syn::{Expr, FieldValue, Lit, LitInt, LitStr, Member, token};
+use syn::punctuated::Punctuated;
+use syn::ExprLit;
+use std::collections::HashMap;
+use syn::parse::{Parse, ParseStream};
+
+pub struct Args(HashMap<String, Expr>);
+
+impl Args {
+    /// Returns the argument with the given `name`, asserting it to be an integer
+    pub fn expect_integer(&self, name: &str) -> &LitInt {
+        let Some(expr) = self.0.get(name) else {
+            panic!("missing required field {}", name)
+        };
+
+        let Expr::Lit(ExprLit { lit: Lit::Int(val), .. }) = expr else {
+            panic!("{} is not an integer", name);
+        };
+
+        val
+    }
+
+    /// Returns the argument with the given `name`, asserting it to be a string
+    pub fn expect_str(&self, name: &str) -> &LitStr {
+        let Some(expr) = self.0.get(name) else {
+            panic!("missing required field {}", name)
+        };
+
+        let Expr::Lit(ExprLit { lit: Lit::Str(val), .. }) = expr else {
+            panic!("{} is not a string", name);
+        };
+
+        val
+    }
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        syn::braced!(content in input);
+
+
+        let args = Punctuated::<FieldValue, token::Comma>::parse_terminated(&content)?;
+        let args = args.into_pairs().map(|p| {
+            let value = p.into_value();
+
+            let ident = match value.member {
+                Member::Named(ident) => ident.to_string(),
+                _ => panic!()
+            };
+
+            (ident, value.expr)
+        });
+
+        Ok(Self(HashMap::from_iter(args)))
+    }
+}

--- a/probes/src/lib.rs
+++ b/probes/src/lib.rs
@@ -1,0 +1,32 @@
+mod args;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use args::Args;
+
+// This just makes printing the `tracing::span` declaration less verbose
+macro_rules! print_span {
+	($lvl:expr, $name:expr) => {
+		proc_macro::TokenStream::from(quote! {
+			 tracing::span!($lvl, $name);
+		})
+	};
+	($lvl:expr, $name:expr, $($id:ident),+) => {
+		proc_macro::TokenStream::from(quote! {
+			 tracing::span!($lvl, $name, $($id = #$id),*)
+		})
+	}
+}
+
+#[proc_macro]
+pub fn ipc_request(input: TokenStream) -> TokenStream {
+	let args = syn::parse_macro_input!(input as Args);
+
+	let id = args.expect_integer("id");
+	let cmd = args.expect_str("cmd");
+	let kind = args.expect_str("kind");
+	let line = args.expect_integer("line");
+	let col = args.expect_integer("col");
+
+	print_span!(tracing::Level::DEBUG, "ipc::request", id, cmd, kind, line, col)
+}

--- a/probes/tests/m.rs
+++ b/probes/tests/m.rs
@@ -1,0 +1,5 @@
+#[test]
+fn m() {
+    let span = probes::ipc_request!({ id: 66, cmd: "foo", kind: "async", line: 10, col: 0 });
+    let _enter = span.enter();
+}


### PR DESCRIPTION
This adds the initial implementation of a `probes` crate that would be reusable later on but for now just illustrates how we could ensure type safety for the tracing data emitted by `tauri`.

This has the major advantage that all emitted data and their schema (as well as idents etc) would be kept in a single, easy to understand crate. This stands in contrast to right now where the tracing statements are spread out over the whole codebase. Additionally the data emitted upstream and the schema devtools understands can easily go out of sync. All this would be mitigated by this approach.

The major downside is that tauri would need to depend on this crate, which doesn't seem all that great. This might not be a problem if we could move the `probes` crate to upstream tauri

closes #24 