### PR TITLE
fix: actually set initialized_at

### DIFF
--- a/devtools/src/aggregator.rs
+++ b/devtools/src/aggregator.rs
@@ -47,7 +47,7 @@ pub(crate) struct Aggregator {
     watchers: Vec<Watcher>,
 
     /// Used to convert `Instant`s to `SystemTime`s and `Timestamp`s
-    base_time: TimeAnchor,
+    pub(crate) base_time: TimeAnchor,
 }
 
 /// Whether to include all buffered events or only those that were buffered since the last update

--- a/devtools/src/tauri_plugin.rs
+++ b/devtools/src/tauri_plugin.rs
@@ -3,6 +3,7 @@ use crate::server::{Server, DEFAULT_ADDRESS};
 use crate::Command;
 use std::sync::Arc;
 use std::thread;
+use std::time::Instant;
 use std::time::SystemTime;
 use tauri::{RunEvent, Runtime};
 use tauri_devtools_wire_format::tauri::Metrics;
@@ -12,7 +13,11 @@ pub(crate) fn init<R: Runtime>(
     aggregator: Aggregator,
     cmd_tx: mpsc::Sender<Command>,
 ) -> tauri::plugin::TauriPlugin<R> {
-    let metrics = Arc::new(RwLock::new(Metrics::default()));
+    let now = Instant::now();
+    let metrics = Arc::new(RwLock::new(Metrics {
+        initialized_at: Some(aggregator.base_time.to_timestamp(now)), // TODO this is horrific
+        ready_at: None,
+    }));
 
     let m = metrics.clone();
     tauri::plugin::Builder::new("probe")


### PR DESCRIPTION
Forgot to actually set the `initialized_at` in Rust, this should fix the loading time indicator.
