### PR TITLE
UI a11y pass

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -41,6 +41,7 @@
     "@protobuf-ts/runtime": "^2.9.1",
     "@protobuf-ts/runtime-rpc": "^2.9.1",
     "@solidjs/router": "^0.8.3",
+    "clsx": "^2.0.0",
     "csp_evaluator": "^1.1.1",
     "solid-js": "^1.7.6",
     "tailwind-scrollbar": "^3.0.5"

--- a/web-client/pnpm-lock.yaml
+++ b/web-client/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@solidjs/router':
     specifier: ^0.8.3
     version: 0.8.3(solid-js@1.7.12)
+  clsx:
+    specifier: ^2.0.0
+    version: 2.0.0
   csp_evaluator:
     specifier: ^1.1.1
     version: 1.1.1
@@ -1627,6 +1630,11 @@ packages:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
     engines: {node: '>=8'}
     dev: true
+
+  /clsx@2.0.0:
+    resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+    dev: false
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}

--- a/web-client/src/components/filter-toggle.tsx
+++ b/web-client/src/components/filter-toggle.tsx
@@ -1,4 +1,4 @@
-import { JSX, Show } from "solid-js";
+import { JSX } from "solid-js";
 import { ToggleButton } from "@kobalte/core";
 
 type FilterToggleProps = {

--- a/web-client/src/components/navigation.tsx
+++ b/web-client/src/components/navigation.tsx
@@ -1,5 +1,6 @@
 import { For } from "solid-js";
-import { A, useParams } from "@solidjs/router";
+import { A, useParams, useLocation } from "@solidjs/router";
+import clsx from "clsx";
 
 const TABS = [
   {
@@ -22,6 +23,7 @@ const TABS = [
 
 export function Navigation() {
   const { host, port } = useParams();
+  const location = useLocation();
   return (
     <nav>
       <ul class="flex border-b flex-start border-b-neutral-800">
@@ -29,9 +31,27 @@ export function Navigation() {
           {(tab) => (
             <li>
               <A
+                // Maximum a11y: respond to both Enter _and_ Space
+                // Buttons natively do this, anchor links not but we
+                // want these to behave like buttons also.
+                // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/button
+                onkeydown={(e) => {
+                  if (e.key !== " ") {
+                    return;
+                  }
+
+                  e.preventDefault();
+                  e.currentTarget.click();
+                }}
                 href={tab.url(host, port)}
-                class="flex border-b-neutral-800 -mb-[1px] items-center justify-center leading-none border-b py-2 px-4 hover:bg-gray-800 hover:border-gray-800"
-                activeClass="border-b-gray-600 hover:border-b-gray-500"
+                class={clsx(
+                  location.pathname === tab.url(host, port)
+                    ? "border-b-gray-500 hover:border-b-gray-400"
+                    : "border-b-gray-800 hover:border-b-gray-600",
+
+                  // The rest
+                  "flex -mb-[1px] items-center justify-center leading-none border-b py-2 px-4 hover:bg-gray-800 hover:border-gray-800"
+                )}
               >
                 {tab.title}
               </A>

--- a/web-client/src/components/toolbar.tsx
+++ b/web-client/src/components/toolbar.tsx
@@ -1,0 +1,11 @@
+import { JSXElement } from "solid-js";
+
+type Props = {
+  children: JSXElement;
+};
+
+export const Toolbar = (props: Props) => (
+  <div class="sticky h-toolbar top-1 bg-black bg-opacity-30 backdrop-blur flex justify-end border-b border-gray-800">
+    {props.children}
+  </div>
+);

--- a/web-client/src/views/dashboard/console.tsx
+++ b/web-client/src/views/dashboard/console.tsx
@@ -3,6 +3,7 @@ import { AutoscrollPane } from "~/components/autoscroll-pane";
 import { FilterToggle } from "~/components/filter-toggle";
 import { formatTimestamp, timestampToDate } from "~/lib/formatters";
 import { useMonitor } from "~/lib/connection/monitor";
+import { Toolbar } from "~/components/toolbar";
 export default function Console() {
   const { monitorData } = useMonitor();
   const [showTimestamp, toggleTimeStamp] = createSignal(true);
@@ -10,7 +11,7 @@ export default function Console() {
 
   return (
     <>
-      <div class="sticky h-toolbar top-0 bg-black bg-opacity-30 backdrop-blur flex justify-end border-b border-gray-800">
+      <Toolbar>
         <FilterToggle
           defaultPressed
           aria-label="time stamps"
@@ -25,7 +26,7 @@ export default function Console() {
         >
           <span>Autoscroll</span>
         </FilterToggle>
-      </div>
+      </Toolbar>
       <AutoscrollPane
         dataStream={monitorData.logs[0]}
         shouldAutoScroll={shouldAutoScroll}

--- a/web-client/src/views/dashboard/span-waterfall.tsx
+++ b/web-client/src/views/dashboard/span-waterfall.tsx
@@ -1,6 +1,7 @@
 import { For, createSignal } from "solid-js";
 import { AutoscrollPane } from "~/components/autoscroll-pane";
 import { FilterToggle } from "~/components/filter-toggle";
+import { Toolbar } from "~/components/toolbar";
 import { useMonitor } from "~/lib/connection/monitor";
 
 export default function SpanWaterfall() {
@@ -9,14 +10,15 @@ export default function SpanWaterfall() {
 
   return (
     <>
-      <FilterToggle
-        aria-label="auto scroll"
-        defaultPressed
-        changeHandler={() => toggleAutoScroll((prev) => !prev)}
-      >
-        Autoscroll
-      </FilterToggle>
-
+      <Toolbar>
+        <FilterToggle
+          aria-label="auto scroll"
+          defaultPressed
+          changeHandler={() => toggleAutoScroll((prev) => !prev)}
+        >
+          Autoscroll
+        </FilterToggle>
+      </Toolbar>
       <AutoscrollPane
         dataStream={monitorData.spans[0]}
         shouldAutoScroll={shouldAutoScroll}


### PR DESCRIPTION
This PR fixes DR-501 and takes care of the accessibility considerations outlined there:

- It makes the devtools keyboard navigable
- Clearly shows active tab states
- Distinguishes hover and focus states