### PR TITLE
(spans) Removes redundant vitest imports

### DIFF
--- a/web-client/src/lib/span/tests/calculate-span-color-from-relative-duration.test.ts
+++ b/web-client/src/lib/span/tests/calculate-span-color-from-relative-duration.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import { calculateSpanColorFromRelativeDuration } from "../calculate-span-color-from-relative-duration";
 
 describe("calculateSpanColorFromRelativeDuration", () => {

--- a/web-client/src/lib/span/tests/find-spans-by-name.test.ts
+++ b/web-client/src/lib/span/tests/find-spans-by-name.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect } from "vitest";
 import { findSpansByName } from "../find-spans-by-name";
 import { metadata } from "./fixtures/metadata";
 import { spans } from "./fixtures/spans";

--- a/web-client/src/lib/span/tests/format-spans-for-ui.test.ts
+++ b/web-client/src/lib/span/tests/format-spans-for-ui.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect } from "vitest";
 import { formatSpansForUi } from "../format-spans-for-ui";
 import { spans } from "./fixtures/spans";
 import { metadata } from "./fixtures/metadata";

--- a/web-client/src/lib/span/tests/formatters.test.ts
+++ b/web-client/src/lib/span/tests/formatters.test.ts
@@ -1,4 +1,3 @@
-import { describe } from "vitest";
 import {
   convertTimestampToNanoseconds,
   formatMs,

--- a/web-client/tests/store/span-metadata.test.ts
+++ b/web-client/tests/store/span-metadata.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import {
   type Metadata,
   Metadata_Kind,

--- a/web-client/tests/store/span-waterfall.test.ts
+++ b/web-client/tests/store/span-waterfall.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import { Span } from "~/lib/connection/monitor";
 import { updatedSpans } from "~/lib/span/update-spans";
 

--- a/web-client/tsconfig.json
+++ b/web-client/tsconfig.json
@@ -24,7 +24,9 @@
     "noFallthroughCasesInSwitch": true,
 
     "jsx": "preserve",
-    "jsxImportSource": "solid-js"
+    "jsxImportSource": "solid-js",
+
+    "types": ["vitest/globals"]
   },
   "include": ["src", "tests"]
 }


### PR DESCRIPTION
Feel free to dismiss this if you don't like it @tejas-crabnebula 

feat: adds vitest globals to typescript config and removes redundant imports

based to #77 