### PR TITLE
fix: set stricter cors header

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+UNSAFE_BYPASS_CLIENT_AUTH = "true" # disable gRPC client auth and CORS checking for local development

--- a/devtools/src/server.rs
+++ b/devtools/src/server.rs
@@ -2,7 +2,6 @@ use crate::{Command, Watcher};
 use async_stream::try_stream;
 use bytes::BytesMut;
 use futures::{FutureExt, Stream, TryStreamExt};
-use std::env;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -112,7 +111,7 @@ impl<R: Runtime> Server<R> {
             .allow_methods([Method::GET, Method::POST])
             .allow_headers(AllowHeaders::any());
 
-        let cors = if env::var("UNSAFE_BYPASS_CLIENT_AUTH").is_ok() {
+        let cors = if option_env!("UNSAFE_BYPASS_CLIENT_AUTH").is_some() {
             cors.allow_origin(tower_http::cors::Any)
         } else {
             cors.allow_origin(HeaderValue::from_str("https://devtools.crabnebula.dev").unwrap())


### PR DESCRIPTION
This makes the CORS header more strict so that only requests from `https://devtools.crabnebula.dev` are allowed.

It also adds a `UNSAFE_BYPASS_CLIENT_AUTH` environment variable that can be set to bypass this stricter check (for local development)

resolves DR-580