### PR TITLE
fix: remove header from codeview

### DIFF
--- a/web-client/src/components/sources/code-view.tsx
+++ b/web-client/src/components/sources/code-view.tsx
@@ -44,7 +44,6 @@ export default function CodeView(props: CodeViewProps) {
 
   return (
     <div class="min-h-full h-max min-w-full w-max bg-black bg-opacity-50">
-      <h1 class="text-2xl p-3">{props.path}</h1>
       <Suspense fallback={<Loader />}>
         <div
           //eslint-disable-next-line solid/no-innerhtml


### PR DESCRIPTION
Having this just feels inconsistent and weird, the path is clear from the sidebar anyway