### PR TITLE
feat: enhance span name for window API calls

### DIFF
--- a/web-client/src/lib/span/get-ipc-request-name.ts
+++ b/web-client/src/lib/span/get-ipc-request-name.ts
@@ -37,7 +37,10 @@ export function getIpcRequestName({ metadata, span }: Options) {
           [];
         try {
           const arg = args.length > 0 ? JSON.parse(args[0]) : {};
-          const cmd = arg.__tauriModule === 'Window' && arg.message.cmd === 'manage' ? arg.message.data.cmd.type : arg.message.cmd
+          const cmd =
+            arg.__tauriModule === "Window" && arg.message.cmd === "manage"
+              ? arg.message.data.cmd.type
+              : arg.message.cmd;
           return `${arg.__tauriModule}.${cmd}`;
         } catch {
           /* intentionally ignore */


### PR DESCRIPTION
changes the cmd name from the constant `Window.manage` to the actual command name. This happens because the window module uses a different message object: https://github.com/tauri-apps/tauri/blob/504627027303ef5a0e855aab2abea64c6964223b/tooling/api/src/window.ts#L479

![image](https://github.com/crabnebula-dev/devtools/assets/118899497/bbd31965-40b3-4358-b50a-b08cee5b667b)
