### PR TITLE
fix: correct devtools url for published version

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [env]
-UNSAFE_BYPASS_CLIENT_AUTH = "true" # disable gRPC client auth and CORS checking for local development
+__DEVTOOLS_LOCAL_DEVELOPMENT = "true" # disable gRPC CORS checking & point to the right URL for local development

--- a/devtools/src/builder.rs
+++ b/devtools/src/builder.rs
@@ -11,10 +11,6 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::Layer as _;
 
-/// URL of the web-based devtool
-/// The server host is added automatically eg: `127.0.0.1:56609`.
-const DEVTOOL_URL: &str = "http://localhost:5173/dash/";
-
 pub struct Builder {
     host: IpAddr,
     port: u16,
@@ -127,7 +123,13 @@ impl Builder {
 
 // This is pretty ugly code I know, but it looks nice in the terminal soo ¯\_(ツ)_/¯
 fn print_link(addr: &SocketAddr) {
-    let url = format!("{DEVTOOL_URL}{}/{}", addr.ip(), addr.port());
+    let url = if option_env!("__DEVTOOLS_LOCAL_DEVELOPMENT").is_some() {
+        "http://localhost:5173/dash/"
+    } else {
+        "https://devtools.crabnebula.dev/dash/"
+    };
+
+    let url = format!("{url}{}/{}", addr.ip(), addr.port());
     println!(
         r#"
    {} {}{}

--- a/devtools/src/server.rs
+++ b/devtools/src/server.rs
@@ -109,7 +109,7 @@ impl<R: Runtime> Server<R> {
             .allow_methods([Method::GET, Method::POST])
             .allow_headers(AllowHeaders::any());
 
-        let cors = if option_env!("UNSAFE_BYPASS_CLIENT_AUTH").is_some() {
+        let cors = if option_env!("__DEVTOOLS_LOCAL_DEVELOPMENT").is_some() {
             cors.allow_origin(tower_http::cors::Any)
         } else {
             cors.allow_origin(HeaderValue::from_str("https://devtools.crabnebula.dev").unwrap())


### PR DESCRIPTION
This points the devtools output to `https://devtools.crabnebula.dev/dash/<ip>/<port>` for published versions and `http://localhost:5173/dash/<ip>/<port>` when inside the local repository

Resolves DR-667