### PR TITLE
fix: crash when sorting

### DIFF
--- a/web-client/src/components/span/span-list.tsx
+++ b/web-client/src/components/span/span-list.tsx
@@ -23,9 +23,12 @@ type Props = {
 export function SpanList(props: Props) {
   const columns = () => {
     return [...Object.keys(props.spans?.[0] ?? {})]
-        .filter((k) => ["name", "initiated", "time", "waterfall"].includes(k))
-        .map(name => ({ name, isSortable: ["name", "initiated", "time"].includes(name) }))
-  }
+      .filter((k) => ["name", "initiated", "time", "waterfall"].includes(k))
+      .map((name) => ({
+        name,
+        isSortable: ["name", "initiated", "time"].includes(name),
+      }));
+  };
   const [, setSearchParams] = useSearchParams();
 
   const sortColumn = (name: SortableColumn) => {
@@ -52,14 +55,17 @@ export function SpanList(props: Props) {
                       sortColumn(resolvedColumn);
                     }
                   }}
-                  onClick={() => column.isSortable && sortColumn(resolvedColumn)}
+                  onClick={() =>
+                    column.isSortable && sortColumn(resolvedColumn)
+                  }
                   class="p-1 cursor-pointer hover:bg-[#ffffff09]"
                 >
                   <div class="flex uppercase select-none items-center gap-2">
                     {column.name}
-                    {props.columnSort.name === resolvedColumn && column.isSortable && (
-                      <SortCaret direction={props.columnSort.direction} />
-                    )}
+                    {props.columnSort.name === resolvedColumn &&
+                      column.isSortable && (
+                        <SortCaret direction={props.columnSort.direction} />
+                      )}
                   </div>
                 </th>
               );

--- a/web-client/src/views/dashboard/calls.tsx
+++ b/web-client/src/views/dashboard/calls.tsx
@@ -57,11 +57,11 @@ export default function Calls() {
         }
 
         if (typeof lhs == "number" && typeof rhs == "number") {
-            return lhs - rhs;
+          return lhs - rhs;
         } else if (typeof lhs == "string" && typeof rhs == "string") {
-            return lhs.localeCompare(rhs)
+          return lhs.localeCompare(rhs);
         } else {
-          return 0 // no sorting
+          return 0; // no sorting
         }
       });
 


### PR DESCRIPTION
Previuosly the app would crash when trying to sort by the name column, this is now fixed. This PR also disallows filtering by the waterfall column, bc that isn't really defined behaviour

resolves DR-672