### PR TITLE
remove user feedback form from Error Boundary

### DIFF
--- a/web-client/src/entry.tsx
+++ b/web-client/src/entry.tsx
@@ -49,8 +49,7 @@ export default function Entry() {
   return (
     <ErrorBoundary
       fallback={(error) => {
-        const eventId = Sentry.captureException(error);
-        Sentry.showReportDialog({ eventId });
+        Sentry.captureException(error);
         return <ErrorRoot error={error} />;
       }}
     >


### PR DESCRIPTION
The User Feedback in Sentry has `email` set as a required field.
**We don't collect any Personal Identifiable Information (PII) information**.

This PR removes the dialog completely and we will iterate through different ways of collecting user feedback anonymously.