### PR TITLE
fix: panic on empty updater spans

### DIFF
--- a/devtools/src/layer.rs
+++ b/devtools/src/layer.rs
@@ -111,7 +111,7 @@ where
             Event::Event {
                 at,
                 metadata,
-                message,
+                message: message.unwrap_or_default(),
                 fields,
                 maybe_parent,
             }

--- a/devtools/src/visitors.rs
+++ b/devtools/src/visitors.rs
@@ -35,11 +35,8 @@ impl EventVisitor {
             message: None,
         }
     }
-    pub(crate) fn result(self) -> (String, Vec<Field>) {
-        (
-            self.message.unwrap(), // TODO handle result here
-            self.field_visitor.result(),
-        )
+    pub(crate) fn result(self) -> (Option<String>, Vec<Field>) {
+        (self.message, self.field_visitor.result())
     }
 }
 


### PR DESCRIPTION
The instrumentation would crash when handling updater spans since they can sometimes have empty fields. This PR fixes that

resolves DR-675