### PR TITLE
Feat/web client 404

### DIFF
--- a/web-client/src/components/errors/error-root.tsx
+++ b/web-client/src/components/errors/error-root.tsx
@@ -1,10 +1,14 @@
 import * as pkg from "~/../package.json";
+import { Switch, Match } from "solid-js";
+import { NotFoundError } from "./not-found-error";
+import { GeneralError } from "./general-error";
 
 type Props = {
   error: unknown;
 };
 
 export function ErrorRoot(props: Props) {
+  const errorMessage = () => props.error?.toString() || String(props.error);
   return (
     <>
       <div class="surf-container">
@@ -12,20 +16,16 @@ export function ErrorRoot(props: Props) {
       </div>
       <div class="p-28 grid grid-rows-[auto_1fr_auto] gap-5 h-screen text-neutral-400 ">
         <header>
-          <h1 class="text-red-400 font-semibold text-6xl">
-            Irrecoverable Error
-          </h1>
-          <div class="text-3xl pt-8">
-            <p>Something terrible happened.</p>
-            <p>The log is on the way and we'll work on it!</p>
-          </div>
+          <Switch fallback={<GeneralError />}>
+            <Match when={errorMessage().includes("404")}>
+              <NotFoundError />
+            </Match>
+          </Switch>
         </header>
         <article class="flex flex-col justify-evenly">
           <div class="p-5 border-2 border-slate-800 rounded-lg font-mono">
             <h2 class="text-4xl relative -top-12">System log</h2>
-            <pre class="text-2xl">
-              {props.error?.toString() || String(props.error)}
-            </pre>
+            <pre class="text-2xl">{errorMessage()}</pre>
             <ul class="pt-12">
               <li>App version: {pkg.version}</li>
               <li>Browser: {window.navigator.userAgent}</li>

--- a/web-client/src/components/errors/general-error.tsx
+++ b/web-client/src/components/errors/general-error.tsx
@@ -1,0 +1,11 @@
+export function GeneralError() {
+  return (
+    <>
+      <h1 class="text-red-400 font-semibold text-6xl">Irrecoverable Error</h1>
+      <div class="text-3xl pt-8">
+        <p>Something terrible happened.</p>
+        <p>The log is on the way and we'll work on it!</p>
+      </div>
+    </>
+  );
+}

--- a/web-client/src/components/errors/not-found-error.tsx
+++ b/web-client/src/components/errors/not-found-error.tsx
@@ -1,0 +1,11 @@
+export function NotFoundError() {
+  return (
+    <>
+      <h1 class="text-red-400 font-semibold text-6xl">404 - Not Found</h1>
+      <div class="text-3xl pt-8">
+        <p>The path your were trying to reach does not exist.</p>
+        <p>If you think it should, don't worry we are already notified.</p>
+      </div>
+    </>
+  );
+}

--- a/web-client/src/entry.tsx
+++ b/web-client/src/entry.tsx
@@ -51,7 +51,7 @@ const ROUTES: RouteDefinition[] = [
   {
     path: "*",
     component: () => {
-      throw new Error("404: The specified path was not found");
+      throw new Error("404 - Not Found: The specified path was not found");
     },
   },
 ];

--- a/web-client/src/entry.tsx
+++ b/web-client/src/entry.tsx
@@ -6,7 +6,7 @@ import {
 } from "@solidjs/router";
 import { lazy, ErrorBoundary } from "solid-js";
 import { setCDN } from "@crabnebula/file-icons";
-import { ErrorRoot } from "./components/error-root.tsx";
+import { ErrorRoot } from "./components/errors/error-root.tsx";
 import * as Sentry from "@sentry/browser";
 
 const ROUTES: RouteDefinition[] = [
@@ -51,11 +51,7 @@ const ROUTES: RouteDefinition[] = [
   {
     path: "*",
     component: () => {
-      /**
-       * momentary workaround
-       */
-      window.location.href = "https://crabnebula.dev/devtools-threw-404";
-      return null;
+      throw new Error("404: The specified path was not found");
     },
   },
 ];


### PR DESCRIPTION
This adds handling for paths that are not found:

https://github.com/crabnebula-dev/devtools/assets/119593300/3c4b3907-2e06-4ac2-8f26-7687fbaa5c50

I simply let the fallback route `*` throw a custom error that then gets handled by the `<ErrorBoundary>`.

What this does not handle at the moment is if there are not found's in the routes themselves. For example someone accessing a non existent file in the sources view. This will have to be handled by them separately.

But with this setup as long as the `Error Message` contains a 404 it will trigger the 404 error view.

This also does not throw a 404 error response which is fine in my opionion since this is a client and not a website.
