### PR TITLE
Add CSP to DevTools app

### DIFF
--- a/clients/web/csp.js
+++ b/clients/web/csp.js
@@ -1,0 +1,24 @@
+import { getCSP, SELF, NONE, UNSAFE_INLINE, UNSAFE_EVAL } from "csp-header";
+
+export function generateCSP(isDev = false) {
+  return getCSP({
+    reportUri: isDev
+      ? ""
+      : "https://o4506303762464768.ingest.sentry.io/api/4506303812272128/security/?sentry_key=57614e75ac5f8c480aed3a2dd1528f13",
+    directives: {
+      "default-src": [SELF],
+      "script-src": isDev ? [SELF, UNSAFE_EVAL] : [SELF],
+      "style-src": isDev ? [SELF, UNSAFE_INLINE] : [SELF],
+      "connect-src": [
+        SELF,
+        "127.0.0.1",
+        "127.0.0.1:3000",
+        "ws://localhost:5173/",
+      ],
+      "img-src": [SELF],
+      "object-src": [NONE],
+    },
+  });
+}
+
+console.log(generateCSP());

--- a/clients/web/csp.js
+++ b/clients/web/csp.js
@@ -7,14 +7,10 @@ export function generateCSP(isDev = false) {
       : "https://o4506303762464768.ingest.sentry.io/api/4506303812272128/security/?sentry_key=57614e75ac5f8c480aed3a2dd1528f13",
     directives: {
       "default-src": [SELF],
+      "frame-src": [SELF],
       "script-src": isDev ? [SELF, UNSAFE_EVAL] : [SELF],
       "style-src": isDev ? [SELF, UNSAFE_INLINE] : [SELF],
-      "connect-src": [
-        SELF,
-        "127.0.0.1",
-        "127.0.0.1:3000",
-        "ws://localhost:5173/",
-      ],
+      "connect-src": [SELF, "127.0.0.1", "ws://localhost:5173/"],
       "img-src": [SELF],
       "object-src": [NONE],
     },

--- a/clients/web/netlify.toml
+++ b/clients/web/netlify.toml
@@ -19,3 +19,9 @@ to = "/:splat"
     base = "clients/web/"
     publish = "dist/"
     command = "pnpm build"
+
+[[headers]]
+  for = "/*"
+  [[headers.values]]
+    X-Frame-Options = "DENY"
+    Content-Security-Policy-Report-Only="default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self' 127.0.0.1 127.0.0.1:3000 ws://localhost:5173/; img-src 'self'; object-src 'none'; report-uri https://o4506303762464768.ingest.sentry.io/api/4506303812272128/security/?sentry_key=57614e75ac5f8c480aed3a2dd1528f13;"

--- a/clients/web/netlify.toml
+++ b/clients/web/netlify.toml
@@ -24,4 +24,4 @@ to = "/:splat"
   for = "/*"
   [[headers.values]]
     X-Frame-Options = "DENY"
-    Content-Security-Policy-Report-Only="default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self' 127.0.0.1 127.0.0.1:3000 ws://localhost:5173/; img-src 'self'; object-src 'none'; report-uri https://o4506303762464768.ingest.sentry.io/api/4506303812272128/security/?sentry_key=57614e75ac5f8c480aed3a2dd1528f13;"
+    Content-Security-Policy-Report-Only="default-src 'self'; frame-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self' 127.0.0.1 ws://localhost:5173/; img-src 'self'; object-src 'none'; report-uri https://o4506303762464768.ingest.sentry.io/api/4506303812272128/security/?sentry_key=57614e75ac5f8c480aed3a2dd1528f13;"

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -27,6 +27,7 @@
     "@vitest/coverage-v8": "^0.34.6",
     "autoprefixer": "^10.4.16",
     "cross-env": "^7.0.3",
+    "csp-header": "^5.2.1",
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-solid": "^0.13.0",

--- a/clients/web/pnpm-lock.yaml
+++ b/clients/web/pnpm-lock.yaml
@@ -97,6 +97,9 @@ devDependencies:
   cross-env:
     specifier: ^7.0.3
     version: 7.0.3
+  csp-header:
+    specifier: ^5.2.1
+    version: 5.2.1
   eslint:
     specifier: ^8.53.0
     version: 8.53.0
@@ -1996,6 +1999,11 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
+
+  /csp-header@5.2.1:
+    resolution: {integrity: sha512-qOJNu39JZkPrbrAM40a1tQCePEPYVIoI6nMDhX4RA07QjU8efS+zyd/zE83XJu85KKazH9NjKlvvlswFMteMgg==}
+    engines: {node: '>=10'}
     dev: true
 
   /csp_evaluator@1.1.1:

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -1,4 +1,5 @@
 import { sentryVitePlugin } from "@sentry/vite-plugin";
+import { generateCSP } from "./csp";
 /**
  * Vitest extends Vite config.
  */
@@ -12,6 +13,9 @@ import { normalizePath } from "vite";
 export default defineConfig({
   server: {
     strictPort: true,
+    headers: {
+      "Content-Security-Policy": generateCSP(true),
+    },
   },
   build: {
     // file-icons need top-level await

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
   server: {
     strictPort: true,
     headers: {
-      "Content-Security-Policy": generateCSP(true),
+      "Content-Security-Policy": generateCSP(
+        process.env.NODE_ENV === "development"
+      ),
     },
   },
   build: {


### PR DESCRIPTION
- [x] Blocking CSP on Dev mode.
- [x] Report-Only CSP on Prod.
- [x] Allow Inline styles and scripts only in Dev because of Vite HMR
- [x] Add a few extra security headers to `netlify.toml`
- [x] Hardcode Sentry `report-uri` 