### PR TITLE
log plugin compat

### DIFF
--- a/devtools/src/layer.rs
+++ b/devtools/src/layer.rs
@@ -98,10 +98,13 @@ where
 
     fn on_event(&self, event: &tracing_core::Event<'_>, ctx: Context<'_, S>) {
         let at = Instant::now();
+        let metadata = event.metadata();
 
         self.send_event(&self.shared.dropped_log_events, || {
-            let metadata = event.metadata();
+            Event::Metadata(metadata)
+        });
 
+        self.send_event(&self.shared.dropped_log_events, || {
             let mut visitor = EventVisitor::new(metadata as *const _ as u64);
             event.record(&mut visitor);
             let (message, fields) = visitor.result();

--- a/devtools/src/tauri_plugin.rs
+++ b/devtools/src/tauri_plugin.rs
@@ -1,11 +1,50 @@
 use crate::aggregator::Aggregator;
 use crate::server::Server;
 use crate::Command;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::thread;
 use std::time::Duration;
 use tauri::Runtime;
 use tokio::sync::mpsc;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct Key {
+    level: u16,
+    file: Option<String>,
+    line: Option<u32>,
+}
+
+#[tauri::command]
+fn log(
+    level: u16,
+    message: String,
+    location: Option<&str>,
+    file: Option<&str>,
+    line: Option<u32>,
+    _key_values: Option<HashMap<String, String>>,
+) -> Result<(), ()> {
+    match level {
+        1 => {
+            tracing::trace!(target: "log", message, log.target = "webview", log.module_path = location, log.file = file, log.line = line);
+        }
+        2 => {
+            tracing::debug!(target: "log", message, log.target = "webview", log.module_path = location, log.file = file, log.line = line)
+        }
+        3 => {
+            tracing::info!(target: "log", message, log.target = "webview", log.module_path = location, log.file = file, log.line = line);
+        }
+        4 => {
+            tracing::warn!(target: "log", message, log.target = "webview", log.module_path = location, log.file = file, log.line = line);
+        }
+        5 => {
+            tracing::error!(target: "log", message, log.target = "webview", log.module_path = location, log.file = file, log.line = line);
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
 
 pub(crate) fn init<R: Runtime>(
     addr: SocketAddr,
@@ -13,7 +52,10 @@ pub(crate) fn init<R: Runtime>(
     aggregator: Aggregator,
     cmd_tx: mpsc::Sender<Command>,
 ) -> tauri::plugin::TauriPlugin<R> {
-    tauri::plugin::Builder::new("probe")
+    // we pretend to be the log plugin so we can intercept the commands
+    // this plugin is incompatible with the log plugin anyway
+    tauri::plugin::Builder::new("log")
+        .invoke_handler(tauri::generate_handler![log])
         .setup(move |app_handle| {
             let server = Server::new(cmd_tx, app_handle.clone());
 

--- a/devtools/src/visitors.rs
+++ b/devtools/src/visitors.rs
@@ -96,11 +96,54 @@ impl Visit for FieldVisitor {
 }
 
 impl Visit for EventVisitor {
-    /// Visit a value that implements `Debug`.
+    /// Visit a double-precision floating point value.
+    fn record_f64(&mut self, field: &tracing_core::Field, value: f64) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_f64(field, value),
+        }
+    }
+
+    /// Visit a signed 64-bit integer value.
+    fn record_i64(&mut self, field: &tracing_core::Field, value: i64) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_i64(field, value),
+        }
+    }
+
+    /// Visit an unsigned 64-bit integer value.
+    fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_u64(field, value),
+        }
+    }
+
+    /// Visit a boolean value.
+    fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_bool(field, value),
+        }
+    }
+
+    /// Visit a string value.
+    fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_str(field, value),
+        }
+    }
+
     fn record_debug(&mut self, field: &tracing_core::Field, value: &dyn Debug) {
         match field.name() {
             // skip fields that are `log` metadata that have already been handled
-            name if name.starts_with("log.") => (),
             "message" if self.message.is_none() => self.message = Some(format!("{value:?}")),
             _ => self.field_visitor.record_debug(field, value),
         }

--- a/web-client/src/views/dashboard/console.tsx
+++ b/web-client/src/views/dashboard/console.tsx
@@ -12,6 +12,7 @@ import { getLevelClasses } from "~/lib/console/get-level-classes";
 import { LogLevelFilter } from "~/components/console/log-level-filter";
 import { NoLogs } from "~/components/console/no-logs";
 import { getFileNameFromPath } from "~/lib/console/get-file-name-from-path";
+import {processFieldValue} from "~/lib/span/process-field-value.ts";
 
 export default function Console() {
   const { monitorData } = useMonitor();
@@ -69,6 +70,14 @@ export default function Console() {
             const timeDate = timestampToDate(at);
             const levelStyle = getLevelClasses(metadata?.level);
 
+            let target = metadata?.target;
+            if (target === "log") {
+              const field = logEvent.fields.find((field) => field.name === "log.target");
+              if (field) {
+                target = processFieldValue(field.value)
+              }
+            }
+
             return (
               <li
                 class={clsx(
@@ -89,8 +98,8 @@ export default function Console() {
                 </Show>
                 <span>{message}</span>
                 <span class="ml-auto flex gap-2 items-center text-xs">
-                  <Show when={metadata?.target}>
-                    <span class="text-gray-600">{metadata!.target}</span>
+                  <Show when={target}>
+                    <span class="text-gray-600">{target}</span>
                   </Show>
                   <Show when={metadata?.location?.file}>
                     {getFileNameFromPath(metadata!.location!.file!)}:

--- a/web-client/src/views/dashboard/console.tsx
+++ b/web-client/src/views/dashboard/console.tsx
@@ -71,10 +71,32 @@ export default function Console() {
             const levelStyle = getLevelClasses(metadata?.level);
 
             let target = metadata?.target;
+            let location = metadata?.location;
             if (target === "log") {
               const field = logEvent.fields.find((field) => field.name === "log.target");
               if (field) {
                 target = processFieldValue(field.value)
+              }
+            }
+            if (target === "webview") {
+              const file = logEvent.fields.find((field) => field.name === "log.file");
+              const line = logEvent.fields.find((field) => field.name === "log.line");
+              const mod = logEvent.fields.find((field) => field.name === "log.module_path");
+
+
+              let mod_file, mod_line
+              if (mod) {
+                const str = processFieldValue(mod.value).replace('log@', '');
+                const [http, url, port, line, col] = str.split(':');
+
+                mod_file = http + url + port;
+                mod_line = parseInt(line)
+                console.log(http, url, port, line, col)
+              }
+
+              location = {
+                file: file ? processFieldValue(file.value) : mod_file,
+                line: line ? parseInt(processFieldValue(line.value)) : mod_line,
               }
             }
 
@@ -101,8 +123,12 @@ export default function Console() {
                   <Show when={target}>
                     <span class="text-gray-600">{target}</span>
                   </Show>
-                  <Show when={metadata?.location?.file}>
-                    {getFileNameFromPath(metadata!.location!.file!)}:
+                  <Show when={location?.file}>
+                    {getFileNameFromPath(location!.file!)}:
+                    {location!.line}
+                  </Show>
+                  <Show when={!metadata?.location?.file && metadata?.location?.modulePath}>
+                    {getFileNameFromPath(metadata!.location!.modulePath!)}:
                     {metadata!.location!.line}
                   </Show>
                 </span>


### PR DESCRIPTION
This adds compatibility with the JS commands from the `tauri-plugin-log` by intercepting calls to the `log` command and emitting them to the unified data stream. 
This also adds handling for properly displaying the source code location of JS messages if available.

resolves #150 