### PR TITLE
fix: improve reported metadata when target is `log`

### DIFF
--- a/devtools/src/layer.rs
+++ b/devtools/src/layer.rs
@@ -98,10 +98,13 @@ where
 
     fn on_event(&self, event: &tracing_core::Event<'_>, ctx: Context<'_, S>) {
         let at = Instant::now();
+        let metadata = event.metadata();
 
         self.send_event(&self.shared.dropped_log_events, || {
-            let metadata = event.metadata();
+            Event::Metadata(metadata)
+        });
 
+        self.send_event(&self.shared.dropped_log_events, || {
             let mut visitor = EventVisitor::new(metadata as *const _ as u64);
             event.record(&mut visitor);
             let (message, fields) = visitor.result();

--- a/devtools/src/visitors.rs
+++ b/devtools/src/visitors.rs
@@ -96,11 +96,54 @@ impl Visit for FieldVisitor {
 }
 
 impl Visit for EventVisitor {
-    /// Visit a value that implements `Debug`.
+    /// Visit a double-precision floating point value.
+    fn record_f64(&mut self, field: &tracing_core::Field, value: f64) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_f64(field, value),
+        }
+    }
+
+    /// Visit a signed 64-bit integer value.
+    fn record_i64(&mut self, field: &tracing_core::Field, value: i64) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_i64(field, value),
+        }
+    }
+
+    /// Visit an unsigned 64-bit integer value.
+    fn record_u64(&mut self, field: &tracing_core::Field, value: u64) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_u64(field, value),
+        }
+    }
+
+    /// Visit a boolean value.
+    fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_bool(field, value),
+        }
+    }
+
+    /// Visit a string value.
+    fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
+        match field.name() {
+            // skip fields that are `log` metadata that have already been handled
+            "message" if self.message.is_none() => self.message = Some(value.to_string()),
+            _ => self.field_visitor.record_str(field, value),
+        }
+    }
+
     fn record_debug(&mut self, field: &tracing_core::Field, value: &dyn Debug) {
         match field.name() {
             // skip fields that are `log` metadata that have already been handled
-            name if name.starts_with("log.") => (),
             "message" if self.message.is_none() => self.message = Some(format!("{value:?}")),
             _ => self.field_visitor.record_debug(field, value),
         }

--- a/web-client/src/views/dashboard/console.tsx
+++ b/web-client/src/views/dashboard/console.tsx
@@ -12,6 +12,7 @@ import { getLevelClasses } from "~/lib/console/get-level-classes";
 import { LogLevelFilter } from "~/components/console/log-level-filter";
 import { NoLogs } from "~/components/console/no-logs";
 import { getFileNameFromPath } from "~/lib/console/get-file-name-from-path";
+import {processFieldValue} from "~/lib/span/process-field-value.ts";
 
 export default function Console() {
   const { monitorData } = useMonitor();
@@ -69,6 +70,14 @@ export default function Console() {
             const timeDate = timestampToDate(at);
             const levelStyle = getLevelClasses(metadata?.level);
 
+            let target = metadata?.target;
+            if (target === "log") {
+              const field = logEvent.fields.find((field) => field.name === "log.target");
+              if (field) {
+                target = processFieldValue(field.value)
+              }
+            }
+
             return (
               <li
                 class={clsx(
@@ -89,8 +98,8 @@ export default function Console() {
                 </Show>
                 <span>{message}</span>
                 <span class="ml-auto flex gap-2 items-center text-xs">
-                  <Show when={metadata?.target}>
-                    <span class="text-gray-600">{metadata!.target}</span>
+                  <Show when={target}>
+                    <span class="text-gray-600">{target}</span>
                   </Show>
                   <Show when={metadata?.location?.file}>
                     {getFileNameFromPath(metadata!.location!.file!)}:

--- a/web-client/src/views/dashboard/console.tsx
+++ b/web-client/src/views/dashboard/console.tsx
@@ -12,7 +12,7 @@ import { getLevelClasses } from "~/lib/console/get-level-classes";
 import { LogLevelFilter } from "~/components/console/log-level-filter";
 import { NoLogs } from "~/components/console/no-logs";
 import { getFileNameFromPath } from "~/lib/console/get-file-name-from-path";
-import {processFieldValue} from "~/lib/span/process-field-value.ts";
+import { processFieldValue } from "~/lib/span/process-field-value.ts";
 
 export default function Console() {
   const { monitorData } = useMonitor();
@@ -72,9 +72,11 @@ export default function Console() {
 
             let target = metadata?.target;
             if (target === "log") {
-              const field = logEvent.fields.find((field) => field.name === "log.target");
+              const field = logEvent.fields.find(
+                (field) => field.name === "log.target"
+              );
               if (field) {
-                target = processFieldValue(field.value)
+                target = processFieldValue(field.value);
               }
             }
 


### PR DESCRIPTION
The `tracing-log` interop layer reports log metadata in a different format, this PR adds handling for these special metadata keys to improve the quality of reported log metadata