### PR TITLE
Fix lint warnings

### DIFF
--- a/web-client/src/components/sources/source-pane.tsx
+++ b/web-client/src/components/sources/source-pane.tsx
@@ -18,22 +18,31 @@ export function SourcePane() {
   return (
     <Show when={params.source} keyed>
       <Suspense fallback={<Loader />}>
-        <Switch fallback={<UnknownView path={filename()} />}>
-          <Match when={contentType()?.startsWith("code/")} keyed>
-            <CodeView
-              path={filename()}
-              size={sizeHint()}
-              lang={contentType()!.replace("code/", "") as HighlighterLang}
-            />
-          </Match>
-          <Match when={contentType()?.startsWith("image/")} keyed>
-            <ImageView
-              path={params.source}
-              size={sizeHint()}
-              type={contentType()!.replace("image/", "")}
-            />
-          </Match>
-        </Switch>
+        <Show when={contentType()}>
+          {(resolvedContentType) => (
+            <Switch fallback={<UnknownView path={filename()} />}>
+              <Match when={resolvedContentType().startsWith("code/")} keyed>
+                <CodeView
+                  path={filename()}
+                  size={sizeHint()}
+                  lang={
+                    resolvedContentType().replace(
+                      "code/",
+                      ""
+                    ) as HighlighterLang
+                  }
+                />
+              </Match>
+              <Match when={resolvedContentType().startsWith("image/")} keyed>
+                <ImageView
+                  path={params.source}
+                  size={sizeHint()}
+                  type={resolvedContentType().replace("image/", "")}
+                />
+              </Match>
+            </Switch>
+          )}
+        </Show>
       </Suspense>
     </Show>
   );

--- a/web-client/src/lib/console/filter-logs.test.ts
+++ b/web-client/src/lib/console/filter-logs.test.ts
@@ -1,3 +1,7 @@
+/* Since this is a test with fake monitor data we don't care about the linter warnings */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import { filterLogs } from "./filter-logs";
 import { fakeMonitorData } from "./fixtures/monitor-data";
 import { getLogMetadata } from "./get-log-metadata";

--- a/web-client/src/lib/console/fixtures/monitor-data.ts
+++ b/web-client/src/lib/console/fixtures/monitor-data.ts
@@ -1,3 +1,7 @@
+/* Since this is fake monitor data for a test we don't care about linter warnings */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 export const fakeMonitorData: any = {
   health: 1,
   metadata: {

--- a/web-client/src/lib/tauri/tauri-conf-schema.ts
+++ b/web-client/src/lib/tauri/tauri-conf-schema.ts
@@ -3,7 +3,7 @@ import tauriConfigSchemaV2 from "./config/tauri-conf-schema-v2.json";
 import { Draft07, JsonSchema, JsonPointer } from "json-schema-library";
 import { createResource, Signal } from "solid-js";
 import { useLocation, useParams } from "@solidjs/router";
-import { awaitEntries, getEntryBytes } from "~/lib/sources/file-entries";
+import { getEntryBytes } from "~/lib/sources/file-entries";
 import { useConfiguration } from "~/components/tauri/configuration-context";
 import { unwrap, reconcile } from "solid-js/store";
 import { bytesToText } from "../code-highlight";

--- a/web-client/src/views/dashboard/console.tsx
+++ b/web-client/src/views/dashboard/console.tsx
@@ -90,11 +90,17 @@ export default function Console() {
                 <span>{message}</span>
                 <span class="ml-auto flex gap-2 items-center text-xs">
                   <Show when={metadata?.target}>
-                    <span class="text-gray-600">{metadata!.target}</span>
+                    {(logTarget) => (
+                      <span class="text-gray-600">{logTarget()}</span>
+                    )}
                   </Show>
                   <Show when={metadata?.location?.file}>
-                    {getFileNameFromPath(metadata!.location!.file!)}:
-                    {metadata!.location!.line}
+                    {(filePath) => (
+                      <>
+                        {getFileNameFromPath(filePath())}:
+                        {metadata?.location?.line ?? ""}
+                      </>
+                    )}
                   </Show>
                 </span>
               </li>


### PR DESCRIPTION
This takes care of the linter warnings we collected.

In most cases using the `<Show>` tag with its accessor function solved the problems. 

For the tests of the console tab I disabled the warnings for now since typing for test fixtures is not as important. 


Fixes DT-70