### PR TITLE
fix: set default flag was not being selected correctly

### DIFF
--- a/web-client/src/components/tauri/configuration-value/flags.tsx
+++ b/web-client/src/components/tauri/configuration-value/flags.tsx
@@ -14,7 +14,9 @@ export function Flags(props: { key: string; value: boolean | string }) {
   return (
     <span class="text-neutral-400 pr-2 font-mono">
       <Switch>
-        <Match when={isDefaultValue(localSchema(), props.value) && isInConfig}>
+        <Match
+          when={isDefaultValue(localSchema(), props.value) && isInConfig()}
+        >
           Set Default
         </Match>
 


### PR DESCRIPTION
I missed this when we did the livestream review. The `isInConfig` function was missing parentheses and because of that the value was incorrectly selected.