### PR TITLE
Fix/tauri tab find line number multiline arrays

### DIFF
--- a/web-client/src/lib/tauri/find-line-number-by-nested-key-in-source.ts
+++ b/web-client/src/lib/tauri/find-line-number-by-nested-key-in-source.ts
@@ -14,9 +14,11 @@ export function findLineNumberByNestedKeyInSource(
   let searchLevel = 0;
 
   let arrayCounter = 0;
+  let skippedFirstArray = false;
 
   for (const line of lines) {
     const currentIndent = line.length - line.trimStart().length;
+
     // If a property is closed we move up a level
     if (keyStack.length > 0 && searchIndents[searchLevel] === currentIndent) {
       keyStack.pop();
@@ -28,11 +30,13 @@ export function findLineNumberByNestedKeyInSource(
     // We make sure we only move into nested properties if the indent is correct
     if (
       searchIndents[searchLevel] === 0 ||
-      searchIndents[searchLevel] + Indent === currentIndent ||
-      searchIndents[searchLevel] + Indent + Indent === currentIndent
+      searchIndents[searchLevel] + Indent === currentIndent
     ) {
       // If the search property matches we move down a level
-      if (line.includes('"' + searchStack[searchLevel] + '":')) {
+      if (
+        lineHasProperty(line, searchStack, searchLevel) ||
+        lineHasOneLineArray(line, searchStack, searchLevel)
+      ) {
         keyStack.push(searchStack[searchLevel]);
         searchLevel++;
         searchIndents.push(currentIndent);
@@ -40,17 +44,28 @@ export function findLineNumberByNestedKeyInSource(
 
       // If the search property is a number we are in an array and assume that we are in the correct spot and only have to search for the correct index
       const arrayPointer = parseInt(searchStack[searchLevel]);
-      const numberOfValues = line.split(",").length;
       if (Number.isInteger(arrayPointer)) {
+        const isOneLineArray = line.includes("[") && line.includes("]");
+        const isObjectClosing = line.includes("},");
+
         if (
-          arrayCounter === arrayPointer ||
-          (numberOfValues > 1 && arrayPointer <= numberOfValues)
+          (arrayCounter === arrayPointer &&
+            !isOneLineArray &&
+            skippedFirstArray &&
+            !isObjectClosing) ||
+          isOneLineArray
         ) {
           keyStack.push(searchStack[searchLevel]);
           searchLevel++;
           searchIndents.push(currentIndent);
         } else {
-          arrayCounter++;
+          if (arrayCounter === 0 && !skippedFirstArray) {
+            skippedFirstArray = true;
+          } else {
+            if (!isObjectClosing) {
+              arrayCounter++;
+            }
+          }
         }
       }
     }
@@ -62,4 +77,25 @@ export function findLineNumberByNestedKeyInSource(
   }
 
   return -1; // Return -1 if the nested key is not found in the JSON string.
+}
+
+function lineHasProperty(
+  line: string,
+  searchStack: string[],
+  searchLevel: number
+) {
+  return line.includes('"' + searchStack[searchLevel] + '":');
+}
+
+function lineHasOneLineArray(
+  line: string,
+  searchStack: string[],
+  searchLevel: number
+) {
+  // If the search property is a number we are in an array and assume that we are in the correct spot and only have to search for the correct index
+  const arrayPointer = parseInt(searchStack[searchLevel]);
+  if (Number.isInteger(arrayPointer)) {
+    return line.includes("[") && line.includes("]");
+  }
+  return false;
 }

--- a/web-client/src/lib/tauri/find-line-number-by-nested-key-in-source.ts
+++ b/web-client/src/lib/tauri/find-line-number-by-nested-key-in-source.ts
@@ -3,99 +3,136 @@ export function findLineNumberByNestedKeyInSource(
   nestedKeyPath: string
 ): number {
   const lines = jsonString.split("\n");
+
   if (nestedKeyPath === "" || nestedKeyPath === undefined) return -1;
-  const searchStack = nestedKeyPath.split(".");
-  // Number of whitespaces used for indentation
-  const Indent = 2;
 
-  let currentLine = 1;
-  const keyStack: string[] = [];
-  const searchIndents: number[] = [0];
-  let searchLevel = 0;
-
-  let arrayCounter = 0;
-  let skippedFirstArray = false;
+  const searchOptions = initSearchOptions(nestedKeyPath);
 
   for (const line of lines) {
-    const currentIndent = line.length - line.trimStart().length;
+    const currentIndent = calculateCurrentIndent(line);
 
     // If a property is closed we move up a level
-    if (keyStack.length > 0 && searchIndents[searchLevel] === currentIndent) {
-      keyStack.pop();
-      searchLevel--;
-      searchIndents.pop();
-      arrayCounter = 0;
+    if (
+      searchOptions.keyStack.length > 0 &&
+      searchOptions.indents[searchOptions.level] === currentIndent
+    ) {
+      moveUp(searchOptions);
     }
 
     // We make sure we only move into nested properties if the indent is correct
     if (
-      searchIndents[searchLevel] === 0 ||
-      searchIndents[searchLevel] + Indent === currentIndent
+      searchOptions.indents[searchOptions.level] === 0 ||
+      searchOptions.indents[searchOptions.level] + searchOptions.indent ===
+        currentIndent
     ) {
-      // If the search property matches we move down a level
+      if (lineHasProperty(searchOptions, line)) {
+        moveDown(searchOptions, currentIndent);
+      }
+
       if (
-        lineHasProperty(line, searchStack, searchLevel) ||
-        lineHasOneLineArray(line, searchStack, searchLevel)
+        lineHasOneLineArray(searchOptions, line) ||
+        lineHasMultiLineArrayKey(searchOptions, line)
       ) {
-        keyStack.push(searchStack[searchLevel]);
-        searchLevel++;
-        searchIndents.push(currentIndent);
-      }
-
-      // If the search property is a number we are in an array and assume that we are in the correct spot and only have to search for the correct index
-      const arrayPointer = parseInt(searchStack[searchLevel]);
-      if (Number.isInteger(arrayPointer)) {
-        const isOneLineArray = line.includes("[") && line.includes("]");
-        const isObjectClosing = line.includes("},");
-
-        if (
-          (arrayCounter === arrayPointer &&
-            !isOneLineArray &&
-            skippedFirstArray &&
-            !isObjectClosing) ||
-          isOneLineArray
-        ) {
-          keyStack.push(searchStack[searchLevel]);
-          searchLevel++;
-          searchIndents.push(currentIndent);
-        } else {
-          if (arrayCounter === 0 && !skippedFirstArray) {
-            skippedFirstArray = true;
-          } else {
-            if (!isObjectClosing) {
-              arrayCounter++;
-            }
-          }
-        }
+        moveDown(searchOptions, currentIndent);
       }
     }
 
-    if (keyStack.length === searchStack.length) {
-      return currentLine;
+    if (searchOptions.keyStack.length === searchOptions.searchStack.length) {
+      return searchOptions.currentLine;
     }
-    currentLine++;
+
+    searchOptions.currentLine++;
   }
 
   return -1; // Return -1 if the nested key is not found in the JSON string.
 }
 
-function lineHasProperty(
-  line: string,
-  searchStack: string[],
-  searchLevel: number
-) {
-  return line.includes('"' + searchStack[searchLevel] + '":');
+type SearchOptions = {
+  searchStack: string[];
+  indent: number;
+  currentLine: number;
+  keyStack: string[];
+  indents: number[];
+  level: number;
+  arrayCounter: number;
+  skippedFirstArray: boolean;
+  hasMultilineArray: boolean;
+};
+
+function initSearchOptions(nestedKeyPath: string) {
+  return {
+    searchStack: nestedKeyPath.split("."),
+    indent: 2,
+    currentLine: 1,
+    keyStack: [],
+    indents: [0],
+    level: 0,
+    arrayCounter: 0,
+    skippedFirstArray: false,
+    hasMultilineArray: false,
+  } satisfies SearchOptions;
 }
 
-function lineHasOneLineArray(
-  line: string,
-  searchStack: string[],
-  searchLevel: number
-) {
+function moveUp(searchOptions: SearchOptions) {
+  searchOptions.keyStack.pop();
+  searchOptions.level--;
+  searchOptions.indents.pop();
+  searchOptions.arrayCounter = 0;
+}
+
+function moveDown(searchOptions: SearchOptions, currentIndent: number) {
+  searchOptions.keyStack.push(searchOptions.searchStack[searchOptions.level]);
+  searchOptions.level++;
+  searchOptions.indents.push(currentIndent);
+}
+
+function calculateCurrentIndent(line: string) {
+  return line.length - line.trimStart().length;
+}
+
+function lineHasProperty(searchOptions: SearchOptions, line: string) {
+  const { searchStack, level } = searchOptions;
+  return line.includes('"' + searchStack[level] + '":');
+}
+
+function lineHasOneLineArray(searchOptions: SearchOptions, line: string) {
+  const { searchStack, level } = searchOptions;
   // If the search property is a number we are in an array and assume that we are in the correct spot and only have to search for the correct index
-  const arrayPointer = parseInt(searchStack[searchLevel]);
+  const arrayPointer = parseInt(searchStack[level]);
   if (Number.isInteger(arrayPointer)) {
     return line.includes("[") && line.includes("]");
   }
+  return false;
+}
+
+function lineHasMultiLineArrayKey(
+  searchOptions: SearchOptions,
+  line: string
+): boolean {
+  // If the search property is a number we are in an array and assume that we are in the correct spot and only have to search for the correct index
+  const arrayPointer = parseInt(searchOptions.searchStack[searchOptions.level]);
+  if (!Number.isInteger(arrayPointer)) return false;
+
+  const isOneLineArray = line.includes("[") && line.includes("]");
+  const isObjectClosing = line.includes("},");
+
+  if (
+    (searchOptions.arrayCounter === arrayPointer &&
+      !isOneLineArray &&
+      searchOptions.skippedFirstArray &&
+      !isObjectClosing) ||
+    isOneLineArray
+  )
+    return true;
+
+  if (searchOptions.arrayCounter === 0 && !searchOptions.skippedFirstArray) {
+    searchOptions.skippedFirstArray = true;
+    return false;
+  }
+
+  if (!isObjectClosing) {
+    searchOptions.arrayCounter++;
+  }
+
   return false;
 }

--- a/web-client/src/lib/tauri/tests/find-line-number-by-nested-key-in-sources.test.ts
+++ b/web-client/src/lib/tauri/tests/find-line-number-by-nested-key-in-sources.test.ts
@@ -1,0 +1,43 @@
+import { findLineNumberByNestedKeyInSource } from "../find-line-number-by-nested-key-in-source";
+import fs from "fs";
+
+const validConfig = fs.readFileSync(
+  "./src/lib/tauri/tests/fixtures/valid-config.json",
+  "utf-8"
+);
+
+describe("findLineNumberByNestedKey", () => {
+  it("should be able to find top level keys.", () => {
+    expect(findLineNumberByNestedKeyInSource(validConfig, "tauri")).toBe(13);
+  });
+
+  it("should be able to find deeply nested keys.", () => {
+    expect(
+      findLineNumberByNestedKeyInSource(validConfig, "tauri.bundle.active")
+    ).toBe(15);
+  });
+
+  it("should not break when the key is not in the config.", () => {
+    expect(
+      findLineNumberByNestedKeyInSource(validConfig, "tauri.windows.bogus")
+    ).toBe(-1);
+  });
+
+  it("should be able to resolve array values.", () => {
+    expect(
+      findLineNumberByNestedKeyInSource(validConfig, "tauri.bundle.icon.2")
+    ).toBe(21);
+  });
+
+  it("should be able to resolve array values and their children.", () => {
+    expect(
+      findLineNumberByNestedKeyInSource(validConfig, "tauri.windows.0.height")
+    ).toBe(43);
+  });
+
+  it("should be able to resolve array values and their children, even if it is the same line.", () => {
+    expect(
+      findLineNumberByNestedKeyInSource(validConfig, "build.distDir.0")
+    ).toBe(4);
+  });
+});


### PR DESCRIPTION
There was still a small bug where the line finder would not be able to properly resolve all the different array cases. I went in and resolved the issue. 

The concrete issue was that with multiline arrays it would not properly be able to resolve the correct array index.

Took this opportunity to also make the code more readable and added a couple of tests.

Fixes: DR-686