### PR TITLE
fix: pick free port

### DIFF
--- a/devtools/src/builder.rs
+++ b/devtools/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::aggregator::Aggregator;
 use crate::layer::Layer;
-use crate::{tauri_plugin, Shared};
+use crate::{tauri_plugin, Error, Shared};
 use colored::Colorize;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
 use std::sync::Arc;
@@ -154,7 +154,7 @@ impl Builder {
         if !port_is_available(port) && !self.strict_port {
             port = (1025..65535)
                 .find(|port| port_is_available(*port))
-                .expect("no free port found");
+                .ok_or(Error::NoFreePorts)?;
         }
 
         let addr = SocketAddr::new(self.host, port);
@@ -167,10 +167,7 @@ impl Builder {
 }
 
 fn port_is_available(port: u16) -> bool {
-    match TcpListener::bind(("127.0.0.1", port)) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
 }
 
 // This is pretty ugly code I know, but it looks nice in the terminal soo ¯\_(ツ)_/¯

--- a/devtools/src/builder.rs
+++ b/devtools/src/builder.rs
@@ -151,7 +151,7 @@ impl Builder {
             .try_init()?;
 
         let mut port = self.port;
-        if !self.strict_port && !port_is_available(port)  {
+        if !self.strict_port && !port_is_available(port) {
             port = (1025..65535)
                 .find(|port| port_is_available(*port))
                 .ok_or(Error::NoFreePorts)?;

--- a/devtools/src/builder.rs
+++ b/devtools/src/builder.rs
@@ -151,7 +151,7 @@ impl Builder {
             .try_init()?;
 
         let mut port = self.port;
-        if !port_is_available(port) && !self.strict_port {
+        if !self.strict_port && !port_is_available(port)  {
             port = (1025..65535)
                 .find(|port| port_is_available(*port))
                 .ok_or(Error::NoFreePorts)?;

--- a/devtools/src/error.rs
+++ b/devtools/src/error.rs
@@ -11,4 +11,7 @@ pub enum Error {
 
     #[error(transparent)]
     RelativizePathError(#[from] std::path::StripPrefixError),
+
+    #[error("No free port found")]
+    NoFreePorts,
 }


### PR DESCRIPTION
Attempts to pick another free port if the default (or configured one) is not available.

Also adds a `strict_port` setting that can be used to disable this behaviour.

resolves DT-33