### PR TITLE
feat: move code highlighter to a separate component and use it throug…

### DIFF
--- a/web-client/src/components/code-higlighter.tsx
+++ b/web-client/src/components/code-higlighter.tsx
@@ -1,0 +1,49 @@
+import { createResource, Suspense } from "solid-js";
+import {
+  createHighlighter,
+  type HighlighterLang,
+  getHighlightedCode,
+} from "~/lib/code-highlight";
+import sanitizeHtml from "sanitize-html";
+import { Highlighter } from "shiki";
+
+type Props = {
+  text: string | undefined;
+  lang: HighlighterLang;
+  highlightedLine?: number;
+};
+
+export function CodeHighlighter(props: Props) {
+  // The used highlighter does not change at all atm so it does not need to be coupled
+  const [highlighter] = createResource(() => createHighlighter());
+
+  const html = (
+    text: string | undefined,
+    highlighter: Highlighter | undefined,
+    lang: HighlighterLang,
+    highlightedLine?: number
+  ) => {
+    if (!text || !highlighter) return undefined;
+    const raw = getHighlightedCode([text, highlighter, lang, highlightedLine]);
+
+    return sanitizeHtml(raw, {
+      allowedTags: ["pre", "code", "span"],
+      allowedAttributes: {
+        pre: ["class"],
+        span: ["class", "style"],
+      },
+    });
+  };
+
+  return (
+    <div
+      //eslint-disable-next-line solid/no-innerhtml
+      innerHTML={html(
+        props.text,
+        highlighter(),
+        props.lang,
+        props.highlightedLine
+      )}
+    />
+  );
+}

--- a/web-client/src/components/code-higlighter.tsx
+++ b/web-client/src/components/code-higlighter.tsx
@@ -1,4 +1,4 @@
-import { createResource, Suspense } from "solid-js";
+import { createResource } from "solid-js";
 import {
   createHighlighter,
   type HighlighterLang,

--- a/web-client/src/components/sources/code-view.tsx
+++ b/web-client/src/components/sources/code-view.tsx
@@ -1,14 +1,8 @@
-import { Highlighter } from "shiki";
 import { Suspense, createResource } from "solid-js";
 import { Loader } from "~/components/loader";
 import { useConnection } from "~/context/connection-provider";
-import {
-  HighlighterLang,
-  createHighlighter,
-  getHighlightedCode,
-  getText,
-} from "~/lib/code-highlight";
-import sanitizeHtml from "sanitize-html";
+import { HighlighterLang, getText } from "~/lib/code-highlight";
+import { CodeHighlighter } from "../code-higlighter";
 
 type CodeViewProps = {
   path: string;
@@ -25,38 +19,13 @@ export default function CodeView(props: CodeViewProps) {
     async (textProps) => getText(...textProps)
   );
 
-  // The used highlighter does not change at all atm so it does not need to be coupled
-  const [highlighter] = createResource(() => createHighlighter());
-
-  const html = (
-    text: string | undefined,
-    highlighter: Highlighter | undefined,
-    lang: HighlighterLang,
-    highlightedLine?: number
-  ) => {
-    if (!text || !highlighter) return undefined;
-    const raw = getHighlightedCode([text, highlighter, lang, highlightedLine]);
-
-    return sanitizeHtml(raw, {
-      allowedTags: ["pre", "code", "span"],
-      allowedAttributes: {
-        pre: ["class"],
-        span: ["class", "style"],
-      },
-    });
-  };
-
   return (
     <div class="min-h-full h-max min-w-full w-max bg-black bg-opacity-50">
       <Suspense fallback={<Loader />}>
-        <div
-          //eslint-disable-next-line solid/no-innerhtml
-          innerHTML={html(
-            text(),
-            highlighter(),
-            props.lang,
-            props.highlightedLine
-          )}
+        <CodeHighlighter
+          text={text()}
+          lang={props.lang}
+          highlightedLine={props.highlightedLine}
         />
       </Suspense>
     </div>

--- a/web-client/src/components/span/span-detail.tsx
+++ b/web-client/src/components/span/span-detail.tsx
@@ -1,14 +1,14 @@
 import { useMonitor } from "~/context/monitor-provider";
-import { Show, createResource } from "solid-js";
+import { Show, Suspense } from "solid-js";
+import { Loader } from "../loader";
 import { UiSpan } from "~/lib/span/format-spans-for-ui";
 import { SpanDetailView } from "./span-detail-view";
 import { getIpcRequestValues } from "~/lib/span/get-ipc-request-value";
 import { processFieldValue } from "~/lib/span/process-field-value";
 import { spanFieldsToObject } from "~/lib/span/span-fields-to-object";
-import { createHighlighter, getHighlightedCode } from "~/lib/code-highlight";
 import { getUiSpanChildren } from "~/lib/span/get-ui-span-children";
 import { isIpcSpanName } from "~/lib/span/isIpcSpanName";
-import sanitizeHtml from "sanitize-html";
+import { CodeHighlighter } from "../code-higlighter";
 
 export function SpanDetail(props: { span: UiSpan }) {
   const { monitorData } = useMonitor();
@@ -68,29 +68,6 @@ export function SpanDetail(props: { span: UiSpan }) {
     }
   };
 
-  const [codeHtml] = createResource(
-    () => [code(), createHighlighter()] as const,
-    async ([code, highlighter]) => {
-      if (code) {
-        const raw = getHighlightedCode({
-          lang: "rust",
-          highlighter: await highlighter,
-        })(code).replace(
-          /\\n/gim, // Turn escaped newlines into actual newlines
-          "\n"
-        );
-
-        return sanitizeHtml(raw, {
-          allowedTags: ["pre", "code", "span"],
-          allowedAttributes: {
-            pre: ["class"],
-            span: ["class", "style"],
-          },
-        });
-      }
-    }
-  );
-
   return (
     <SpanDetailView
       name={props.span.name ?? "-"}
@@ -98,15 +75,14 @@ export function SpanDetail(props: { span: UiSpan }) {
       valuesSectionTitle={valuesSectionTitle()}
       values={values() ?? []}
     >
-      <Show when={codeHtml()}>
-        {(html) => (
+      <Show when={code()}>
+        {(raw) => (
           <div class="grid gap-2">
             <h2 class="text-xl p-4">Response</h2>
             <pre class="bg-black rounded max-w-full overflow-auto">
-              <code
-                // eslint-disable-next-line solid/no-innerhtml
-                innerHTML={html()}
-              />
+              <Suspense fallback={<Loader />}>
+                <CodeHighlighter text={raw()} lang="rust" />
+              </Suspense>
             </pre>
           </div>
         )}

--- a/web-client/src/components/tauri/json-view.tsx
+++ b/web-client/src/components/tauri/json-view.tsx
@@ -26,7 +26,7 @@ export default function JsonView() {
   return (
     <Show when={params.config}>
       <Show
-        when={config()?.key !== "loaded"}
+        when={config() && config()?.key !== "loaded"}
         fallback={
           <p class="p-3">
             This configuration is parsed and merged, so there is no direct


### PR DESCRIPTION
This is my proposal for moving the "code highlighting" into it's own component and reuse it throughout the component. This way we don't care how you retrieved the code to highlight but can make sure that it is always sanitized. 

Builds on: #164