### PR TITLE
feat: add span details numbers

### DIFF
--- a/web-client/src/components/span/span-detail-trace.tsx
+++ b/web-client/src/components/span/span-detail-trace.tsx
@@ -16,76 +16,90 @@ export function SpanDetailTrace(props: {
     longest: number;
   };
 }) {
-  const busy = () => props.span.original.enters.reduce((acc, enter, i) => {
-    const exit = props.span.original.exits[i];
+  const busy = () =>
+    props.span.original.enters.reduce((acc, enter, i) => {
+      const exit = props.span.original.exits[i];
 
-    return acc + (exit.timestamp - enter.timestamp)
-  }, 0)
+      return acc + (exit.timestamp - enter.timestamp);
+    }, 0);
 
   return (
-      <Popover.Root>
-        <Popover.Trigger class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]" as="tr">
-      <td class="py-1 px-4">{props.span.name}</td>
-      <td class="py-1 px-4 relative w-[70%]">
-        <div class="relative">
-          <div class="bg-gray-800 w-full absolute rounded-sm h-2" />
-          <div
-            class="relative h-2"
-            style={computeWaterfallStyle(
-              props.span,
-              props.durations.start,
-              props.durations.end,
-              props.durations.shortest,
-              props.durations.longest
-            )}
-          >
-            {/* Slices is "time slices" as in multiple entry points to a given span */}
-            <For each={computeSlices(props.span.original)}>
-              {(slice) => (
-                <Popover.Root>
-                  <Popover.Trigger
-                    class="absolute bg-teal-500 top-0 left-0 h-full hover:bg-teal-300"
-                    style={{
-                      width: `${slice.width}%`,
-                      "margin-left": `${slice.marginLeft}%`,
-                    }}
-                  ></Popover.Trigger>
-                  <Popover.Portal>
-                    <Popover.Content
-                        class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
-                        style={{"max-width": "min(calc(100vw - 16px), 380px)"}}
-                    >
-                      <Popover.Arrow/>
-                      <span>Time</span>
-                      <span>{((slice.exited - slice.entered) / 1e6).toFixed(3)}ms</span>
-                      <span>Thread</span>
-                      <span>{slice.threadID}</span>
-                      <span>Start</span>
-                      <span>{getDetailedTime(new Date(slice.entered / 1e6))}</span>
-                      <span>End</span>
-                      <span>{getDetailedTime(new Date(slice.exited / 1e6))}</span>
-                    </Popover.Content>
-                  </Popover.Portal>
-                </Popover.Root>
+    <Popover.Root>
+      <Popover.Trigger
+        class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]"
+        as="tr"
+      >
+        <td class="py-1 px-4">{props.span.name}</td>
+        <td class="py-1 px-4 relative w-[70%]">
+          <div class="relative">
+            <div class="bg-gray-800 w-full absolute rounded-sm h-2" />
+            <div
+              class="relative h-2"
+              style={computeWaterfallStyle(
+                props.span,
+                props.durations.start,
+                props.durations.end,
+                props.durations.shortest,
+                props.durations.longest
               )}
-            </For>
+            >
+              {/* Slices is "time slices" as in multiple entry points to a given span */}
+              <For each={computeSlices(props.span.original)}>
+                {(slice) => (
+                  <Popover.Root>
+                    <Popover.Trigger
+                      class="absolute bg-teal-500 top-0 left-0 h-full hover:bg-teal-300"
+                      style={{
+                        width: `${slice.width}%`,
+                        "margin-left": `${slice.marginLeft}%`,
+                      }}
+                    ></Popover.Trigger>
+                    <Popover.Portal>
+                      <Popover.Content
+                        class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
+                        style={{
+                          "max-width": "min(calc(100vw - 16px), 380px)",
+                        }}
+                      >
+                        <Popover.Arrow />
+                        <span>Time</span>
+                        <span>
+                          {((slice.exited - slice.entered) / 1e6).toFixed(3)}ms
+                        </span>
+                        <span>Thread</span>
+                        <span>{slice.threadID}</span>
+                        <span>Start</span>
+                        <span>
+                          {getDetailedTime(new Date(slice.entered / 1e6))}
+                        </span>
+                        <span>End</span>
+                        <span>
+                          {getDetailedTime(new Date(slice.exited / 1e6))}
+                        </span>
+                      </Popover.Content>
+                    </Popover.Portal>
+                  </Popover.Root>
+                )}
+              </For>
+            </div>
           </div>
-        </div>
-      </td>
-      <td class="py-1 px-4">{props.span.time.toFixed(2)}ms</td>
-        </Popover.Trigger>
-        <Popover.Portal>
-          <Popover.Content
-              class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
-              style={{"max-width": "min(calc(100vw - 16px), 380px)"}}>
-            <Popover.Arrow/>
-            <span>{props.span.name}</span><span />
-            <span>Busy</span>
-            <span>{(busy() / 1e6).toFixed(3)}ms</span>
-            <span>Idle</span>
-            <span>{(props.span.time - busy() / 1e6).toFixed(3)}ms</span>
-          </Popover.Content>
-        </Popover.Portal>
-      </Popover.Root>
+        </td>
+        <td class="py-1 px-4">{props.span.time.toFixed(2)}ms</td>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
+          style={{ "max-width": "min(calc(100vw - 16px), 380px)" }}
+        >
+          <Popover.Arrow />
+          <span>{props.span.name}</span>
+          <span />
+          <span>Busy</span>
+          <span>{(busy() / 1e6).toFixed(3)}ms</span>
+          <span>Idle</span>
+          <span>{(props.span.time - busy() / 1e6).toFixed(3)}ms</span>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }

--- a/web-client/src/components/span/span-detail-trace.tsx
+++ b/web-client/src/components/span/span-detail-trace.tsx
@@ -16,8 +16,15 @@ export function SpanDetailTrace(props: {
     longest: number;
   };
 }) {
+  const busy = () => props.span.original.enters.reduce((acc, enter, i) => {
+    const exit = props.span.original.exits[i];
+
+    return acc + (exit.timestamp - enter.timestamp)
+  }, 0)
+
   return (
-    <tr class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]">
+      <Popover.Root>
+        <Popover.Trigger class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]" as="tr">
       <td class="py-1 px-4">{props.span.name}</td>
       <td class="py-1 px-4 relative w-[70%]">
         <div class="relative">
@@ -37,7 +44,7 @@ export function SpanDetailTrace(props: {
               {(slice) => (
                 <Popover.Root>
                   <Popover.Trigger
-                    class="absolute bg-teal-500 top-0 left-0 h-full"
+                    class="absolute bg-teal-500 top-0 left-0 h-full hover:bg-teal-300"
                     style={{
                       width: `${slice.width}%`,
                       "margin-left": `${slice.marginLeft}%`,
@@ -45,22 +52,18 @@ export function SpanDetailTrace(props: {
                   ></Popover.Trigger>
                   <Popover.Portal>
                     <Popover.Content
-                      class="z-50 bg-gray-800 rounded-sm drop-shadow-2xl p-1 focus:outline-none"
-                      style={{ "max-width": "min(calc(100vw - 16px), 380px)" }}
+                        class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
+                        style={{"max-width": "min(calc(100vw - 16px), 380px)"}}
                     >
-                      <Popover.Arrow />
-                      <p>
-                        time:{" "}
-                        {((slice.exited - slice.entered) / 1e6).toFixed(3)}ms
-                      </p>
-                      <p>on thread: {slice.threadID}</p>
-                      <p>
-                        entered:{" "}
-                        {getDetailedTime(new Date(slice.entered / 1e6))}
-                      </p>
-                      <p>
-                        exited: {getDetailedTime(new Date(slice.exited / 1e6))}
-                      </p>
+                      <Popover.Arrow/>
+                      <span>Time</span>
+                      <span>{((slice.exited - slice.entered) / 1e6).toFixed(3)}ms</span>
+                      <span>Thread</span>
+                      <span>{slice.threadID}</span>
+                      <span>Start</span>
+                      <span>{getDetailedTime(new Date(slice.entered / 1e6))}</span>
+                      <span>End</span>
+                      <span>{getDetailedTime(new Date(slice.exited / 1e6))}</span>
                     </Popover.Content>
                   </Popover.Portal>
                 </Popover.Root>
@@ -70,6 +73,19 @@ export function SpanDetailTrace(props: {
         </div>
       </td>
       <td class="py-1 px-4">{props.span.time.toFixed(2)}ms</td>
-    </tr>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+              class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
+              style={{"max-width": "min(calc(100vw - 16px), 380px)"}}>
+            <Popover.Arrow/>
+            <span>{props.span.name}</span><span />
+            <span>Busy</span>
+            <span>{(busy() / 1e6).toFixed(3)}ms</span>
+            <span>Idle</span>
+            <span>{(props.span.time - busy() / 1e6).toFixed(3)}ms</span>
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
   );
 }

--- a/web-client/src/components/span/span-detail-trace.tsx
+++ b/web-client/src/components/span/span-detail-trace.tsx
@@ -5,7 +5,7 @@ import {
   computeSlices,
 } from "~/lib/span/normalize-spans";
 import { Popover } from "@kobalte/core";
-import {getDetailedTime} from "~/lib/formatters.ts";
+import { getDetailedTime } from "~/lib/formatters.ts";
 
 export function SpanDetailTrace(props: {
   span: UiSpan;
@@ -17,54 +17,59 @@ export function SpanDetailTrace(props: {
   };
 }) {
   return (
-      <tr class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]">
-        <td class="py-1 px-4">{props.span.name}</td>
-        <td class="py-1 px-4 relative w-[70%]">
-          <div class="relative">
-            <div class="bg-gray-800 w-full absolute rounded-sm h-2"/>
-            <div
-                class="relative h-2"
-                style={computeWaterfallStyle(
-                    props.span,
-                    props.durations.start,
-                    props.durations.end,
-                    props.durations.shortest,
-                    props.durations.longest
-                )}
-            >
-              {/* Slices is "time slices" as in multiple entry points to a given span */}
-              <For each={computeSlices(props.span.original)}>
-                {(slice) => (
-                    <Popover.Root>
-                      <Popover.Trigger class="absolute bg-teal-500 top-0 left-0 h-full"
-                                       style={{width: `${slice.width}%`, "margin-left": `${slice.marginLeft}%`}}>
-                      </Popover.Trigger>
-                      <Popover.Portal>
-                        <Popover.Content class="z-50 bg-gray-800 rounded-sm drop-shadow-2xl p-1 focus:outline-none"
-                                         style={{"max-width": "min(calc(100vw - 16px), 380px)"}}>
-                          <Popover.Arrow/>
-                          <p>
-                            time: {((slice.exited - slice.entered) / 1e6).toFixed(3)}ms ({slice.busy.toFixed(3)}% of
-                            total)
-                          </p>
-                          <p>
-                            on thread: {slice.threadID}
-                          </p>
-                          <p>
-                            entered: {getDetailedTime(new Date(slice.entered / 1e6))}
-                          </p>
-                          <p>
-                            exited: {getDetailedTime(new Date(slice.exited / 1e6))}
-                          </p>
-                        </Popover.Content>
-                      </Popover.Portal>
-                    </Popover.Root>
-                )}
-              </For>
-            </div>
+    <tr class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]">
+      <td class="py-1 px-4">{props.span.name}</td>
+      <td class="py-1 px-4 relative w-[70%]">
+        <div class="relative">
+          <div class="bg-gray-800 w-full absolute rounded-sm h-2" />
+          <div
+            class="relative h-2"
+            style={computeWaterfallStyle(
+              props.span,
+              props.durations.start,
+              props.durations.end,
+              props.durations.shortest,
+              props.durations.longest
+            )}
+          >
+            {/* Slices is "time slices" as in multiple entry points to a given span */}
+            <For each={computeSlices(props.span.original)}>
+              {(slice) => (
+                <Popover.Root>
+                  <Popover.Trigger
+                    class="absolute bg-teal-500 top-0 left-0 h-full"
+                    style={{
+                      width: `${slice.width}%`,
+                      "margin-left": `${slice.marginLeft}%`,
+                    }}
+                  ></Popover.Trigger>
+                  <Popover.Portal>
+                    <Popover.Content
+                      class="z-50 bg-gray-800 rounded-sm drop-shadow-2xl p-1 focus:outline-none"
+                      style={{ "max-width": "min(calc(100vw - 16px), 380px)" }}
+                    >
+                      <Popover.Arrow />
+                      <p>
+                        time:{" "}
+                        {((slice.exited - slice.entered) / 1e6).toFixed(3)}ms
+                      </p>
+                      <p>on thread: {slice.threadID}</p>
+                      <p>
+                        entered:{" "}
+                        {getDetailedTime(new Date(slice.entered / 1e6))}
+                      </p>
+                      <p>
+                        exited: {getDetailedTime(new Date(slice.exited / 1e6))}
+                      </p>
+                    </Popover.Content>
+                  </Popover.Portal>
+                </Popover.Root>
+              )}
+            </For>
           </div>
-        </td>
-        <td class="py-1 px-4">{props.span.time.toFixed(2)}ms</td>
-      </tr>
+        </div>
+      </td>
+      <td class="py-1 px-4">{props.span.time.toFixed(2)}ms</td>
+    </tr>
   );
 }

--- a/web-client/src/components/span/span-detail-trace.tsx
+++ b/web-client/src/components/span/span-detail-trace.tsx
@@ -1,4 +1,4 @@
-import { For } from "solid-js";
+import { For, JSXElement, Show } from "solid-js";
 import { UiSpan } from "~/lib/span/format-spans-for-ui";
 import { Span } from "~/lib/connection/monitor";
 import {
@@ -63,18 +63,18 @@ function SpanDetailPopOverContent(props: { span: UiSpan }) {
 
   return (
     <Popover.Content
-      class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
+      class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none"
       style={{ "max-width": "min(calc(100vw - 16px), 380px)" }}
     >
-      <Popover.Arrow />
-      <span>{props.span.name}</span>
-      <span />
-      <span>Busy</span>
-      <span>{(busy(props.span.original) / 1e6).toFixed(3)}ms</span>
-      <span>Idle</span>
-      <span>
-        {(props.span.time - busy(props.span.original) / 1e6).toFixed(3)}ms
-      </span>
+      <ToolTipContent>
+        <ToolTipRow title={props.span.name} />
+        <ToolTipRow title="Busy">
+          {(busy(props.span.original) / 1e6).toFixed(3)}ms
+        </ToolTipRow>
+        <ToolTipRow title="Idle">
+          {(props.span.time - busy(props.span.original) / 1e6).toFixed(3)}ms
+        </ToolTipRow>
+      </ToolTipContent>
     </Popover.Content>
   );
 }
@@ -99,24 +99,46 @@ function SpanDetailSlice(props: {
       />
       <Popover.Portal>
         <Popover.Content
-          class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
+          class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none"
           style={{
             "max-width": "min(calc(100vw - 16px), 380px)",
           }}
         >
-          <Popover.Arrow />
-          <span>Time</span>
-          <span>
-            {((props.slice.exited - props.slice.entered) / 1e6).toFixed(3)}ms
-          </span>
-          <span>Thread</span>
-          <span>{props.slice.threadID}</span>
-          <span>Start</span>
-          <span>{getDetailedTime(new Date(props.slice.entered / 1e6))}</span>
-          <span>End</span>
-          <span>{getDetailedTime(new Date(props.slice.exited / 1e6))}</span>
+          <ToolTipContent>
+            <ToolTipRow title="Time">
+              {((props.slice.exited - props.slice.entered) / 1e6).toFixed(3)}
+              ms
+            </ToolTipRow>
+            <ToolTipRow title="Thread">{props.slice.threadID}</ToolTipRow>
+            <ToolTipRow title="Start">
+              {getDetailedTime(new Date(props.slice.entered / 1e6))}
+            </ToolTipRow>
+            <ToolTipRow title="End">
+              {getDetailedTime(new Date(props.slice.exited / 1e6))}
+            </ToolTipRow>
+          </ToolTipContent>
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>
+  );
+}
+
+function ToolTipContent(props: { children: JSXElement }) {
+  return (
+    <>
+      <Popover.Arrow />
+      <table>{props.children}</table>
+    </>
+  );
+}
+
+function ToolTipRow(props: { title: string; children?: JSXElement }) {
+  return (
+    <tr class="grid grid-cols-2 text-left">
+      <th>{props.title}</th>
+      <Show when={props.children}>
+        <td>{props.children}</td>
+      </Show>
+    </tr>
   );
 }

--- a/web-client/src/components/span/span-detail-trace.tsx
+++ b/web-client/src/components/span/span-detail-trace.tsx
@@ -4,6 +4,8 @@ import {
   computeWaterfallStyle,
   computeSlices,
 } from "~/lib/span/normalize-spans";
+import { Popover } from "@kobalte/core";
+import {getDetailedTime} from "~/lib/formatters.ts";
 
 export function SpanDetailTrace(props: {
   span: UiSpan;
@@ -15,33 +17,54 @@ export function SpanDetailTrace(props: {
   };
 }) {
   return (
-    <tr class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]">
-      <td class="py-1 px-4">{props.span.name}</td>
-      <td class="py-1 px-4 relative w-[60%]">
-        <div class="relative w-[90%]">
-          <div class="bg-gray-800 w-full absolute rounded-sm h-2" />
-          <div
-            class="relative h-2"
-            style={computeWaterfallStyle(
-              props.span,
-              props.durations.start,
-              props.durations.end,
-              props.durations.shortest,
-              props.durations.longest
-            )}
-          >
-            {/* Slices is "time slices" as in multiple entry points to a given span */}
-            <For each={computeSlices(props.span.original)}>
-              {(slice) => (
-                <div
-                  class="absolute bg-teal-500 top-0 left-0 h-full"
-                  style={slice}
-                />
-              )}
-            </For>
+      <tr class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]">
+        <td class="py-1 px-4">{props.span.name}</td>
+        <td class="py-1 px-4 relative w-[70%]">
+          <div class="relative">
+            <div class="bg-gray-800 w-full absolute rounded-sm h-2"/>
+            <div
+                class="relative h-2"
+                style={computeWaterfallStyle(
+                    props.span,
+                    props.durations.start,
+                    props.durations.end,
+                    props.durations.shortest,
+                    props.durations.longest
+                )}
+            >
+              {/* Slices is "time slices" as in multiple entry points to a given span */}
+              <For each={computeSlices(props.span.original)}>
+                {(slice) => (
+                    <Popover.Root>
+                      <Popover.Trigger class="absolute bg-teal-500 top-0 left-0 h-full"
+                                       style={{width: `${slice.width}%`, "margin-left": `${slice.marginLeft}%`}}>
+                      </Popover.Trigger>
+                      <Popover.Portal>
+                        <Popover.Content class="z-50 bg-gray-800 rounded-sm drop-shadow-2xl p-1 focus:outline-none"
+                                         style={{"max-width": "min(calc(100vw - 16px), 380px)"}}>
+                          <Popover.Arrow/>
+                          <p>
+                            time: {((slice.exited - slice.entered) / 1e6).toFixed(3)}ms ({slice.busy.toFixed(3)}% of
+                            total)
+                          </p>
+                          <p>
+                            on thread: {slice.threadID}
+                          </p>
+                          <p>
+                            entered: {getDetailedTime(new Date(slice.entered / 1e6))}
+                          </p>
+                          <p>
+                            exited: {getDetailedTime(new Date(slice.exited / 1e6))}
+                          </p>
+                        </Popover.Content>
+                      </Popover.Portal>
+                    </Popover.Root>
+                )}
+              </For>
+            </div>
           </div>
-        </div>
-      </td>
-    </tr>
+        </td>
+        <td class="py-1 px-4">{props.span.time.toFixed(2)}ms</td>
+      </tr>
   );
 }

--- a/web-client/src/components/span/span-detail-trace.tsx
+++ b/web-client/src/components/span/span-detail-trace.tsx
@@ -1,5 +1,6 @@
 import { For } from "solid-js";
 import { UiSpan } from "~/lib/span/format-spans-for-ui";
+import { Span } from "~/lib/connection/monitor";
 import {
   computeWaterfallStyle,
   computeSlices,
@@ -16,13 +17,6 @@ export function SpanDetailTrace(props: {
     longest: number;
   };
 }) {
-  const busy = () =>
-    props.span.original.enters.reduce((acc, enter, i) => {
-      const exit = props.span.original.exits[i];
-
-      return acc + (exit.timestamp - enter.timestamp);
-    }, 0);
-
   return (
     <Popover.Root>
       <Popover.Trigger
@@ -45,41 +39,7 @@ export function SpanDetailTrace(props: {
             >
               {/* Slices is "time slices" as in multiple entry points to a given span */}
               <For each={computeSlices(props.span.original)}>
-                {(slice) => (
-                  <Popover.Root>
-                    <Popover.Trigger
-                      class="absolute bg-teal-500 top-0 left-0 h-full hover:bg-teal-300"
-                      style={{
-                        width: `${slice.width}%`,
-                        "margin-left": `${slice.marginLeft}%`,
-                      }}
-                    ></Popover.Trigger>
-                    <Popover.Portal>
-                      <Popover.Content
-                        class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
-                        style={{
-                          "max-width": "min(calc(100vw - 16px), 380px)",
-                        }}
-                      >
-                        <Popover.Arrow />
-                        <span>Time</span>
-                        <span>
-                          {((slice.exited - slice.entered) / 1e6).toFixed(3)}ms
-                        </span>
-                        <span>Thread</span>
-                        <span>{slice.threadID}</span>
-                        <span>Start</span>
-                        <span>
-                          {getDetailedTime(new Date(slice.entered / 1e6))}
-                        </span>
-                        <span>End</span>
-                        <span>
-                          {getDetailedTime(new Date(slice.exited / 1e6))}
-                        </span>
-                      </Popover.Content>
-                    </Popover.Portal>
-                  </Popover.Root>
-                )}
+                {(slice) => <SpanDetailSlice slice={slice} />}
               </For>
             </div>
           </div>
@@ -87,17 +47,74 @@ export function SpanDetailTrace(props: {
         <td class="py-1 px-4">{props.span.time.toFixed(2)}ms</td>
       </Popover.Trigger>
       <Popover.Portal>
+        <SpanDetailPopOverContent span={props.span} />
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+function SpanDetailPopOverContent(props: { span: UiSpan }) {
+  const busy = (span: Span) =>
+    span.enters.reduce((acc, enter, i) => {
+      const exit = span.exits[i];
+
+      return acc + (exit.timestamp - enter.timestamp);
+    }, 0);
+
+  return (
+    <Popover.Content
+      class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
+      style={{ "max-width": "min(calc(100vw - 16px), 380px)" }}
+    >
+      <Popover.Arrow />
+      <span>{props.span.name}</span>
+      <span />
+      <span>Busy</span>
+      <span>{(busy(props.span.original) / 1e6).toFixed(3)}ms</span>
+      <span>Idle</span>
+      <span>
+        {(props.span.time - busy(props.span.original) / 1e6).toFixed(3)}ms
+      </span>
+    </Popover.Content>
+  );
+}
+
+function SpanDetailSlice(props: {
+  slice: {
+    entered: number;
+    exited: number;
+    threadID: number;
+    width: number;
+    marginLeft: number;
+  };
+}) {
+  return (
+    <Popover.Root>
+      <Popover.Trigger
+        class="absolute bg-teal-500 top-0 left-0 h-full hover:bg-teal-300"
+        style={{
+          width: `${props.slice.width}%`,
+          "margin-left": `${props.slice.marginLeft}%`,
+        }}
+      />
+      <Popover.Portal>
         <Popover.Content
           class="z-50 bg-gray-700 rounded-sm drop-shadow-2xl px-2 py-1 focus:outline-none grid grid-cols-2"
-          style={{ "max-width": "min(calc(100vw - 16px), 380px)" }}
+          style={{
+            "max-width": "min(calc(100vw - 16px), 380px)",
+          }}
         >
           <Popover.Arrow />
-          <span>{props.span.name}</span>
-          <span />
-          <span>Busy</span>
-          <span>{(busy() / 1e6).toFixed(3)}ms</span>
-          <span>Idle</span>
-          <span>{(props.span.time - busy() / 1e6).toFixed(3)}ms</span>
+          <span>Time</span>
+          <span>
+            {((props.slice.exited - props.slice.entered) / 1e6).toFixed(3)}ms
+          </span>
+          <span>Thread</span>
+          <span>{props.slice.threadID}</span>
+          <span>Start</span>
+          <span>{getDetailedTime(new Date(props.slice.entered / 1e6))}</span>
+          <span>End</span>
+          <span>{getDetailedTime(new Date(props.slice.exited / 1e6))}</span>
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>

--- a/web-client/src/lib/connection/monitor.ts
+++ b/web-client/src/lib/connection/monitor.ts
@@ -15,8 +15,8 @@ export type Span = {
   metadataId: bigint;
   fields: Field[];
   createdAt: number;
-  enters: { timestamp: number, threadID: number }[];
-  exits: { timestamp: number, threadID: number }[];
+  enters: { timestamp: number; threadID: number }[];
+  exits: { timestamp: number; threadID: number }[];
   closedAt: number;
   duration: number;
 };

--- a/web-client/src/lib/connection/monitor.ts
+++ b/web-client/src/lib/connection/monitor.ts
@@ -15,8 +15,8 @@ export type Span = {
   metadataId: bigint;
   fields: Field[];
   createdAt: number;
-  enters: number[];
-  exits: number[];
+  enters: { timestamp: number, threadID: number }[];
+  exits: { timestamp: number, threadID: number }[];
   closedAt: number;
   duration: number;
 };

--- a/web-client/src/lib/formatters.ts
+++ b/web-client/src/lib/formatters.ts
@@ -36,3 +36,13 @@ export function getTime(date: Date) {
     second: "2-digit",
   }).format(date);
 }
+
+export function getDetailedTime(date: Date) {
+  return Intl.DateTimeFormat('en', {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    second: "2-digit",
+    fractionalSecondDigits: 3
+  }).format(date);
+}

--- a/web-client/src/lib/formatters.ts
+++ b/web-client/src/lib/formatters.ts
@@ -38,11 +38,11 @@ export function getTime(date: Date) {
 }
 
 export function getDetailedTime(date: Date) {
-  return Intl.DateTimeFormat('en', {
+  return Intl.DateTimeFormat("en", {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
     second: "2-digit",
-    fractionalSecondDigits: 3
+    fractionalSecondDigits: 3,
   }).format(date);
 }

--- a/web-client/src/lib/span/normalize-spans.ts
+++ b/web-client/src/lib/span/normalize-spans.ts
@@ -54,20 +54,23 @@ export function computeWaterfallStyle(
 }
 
 export function computeSlices(span: Span) {
-  const allExits = span.exits.reduce((acc, e) => acc + e, 0);
-  const allEnters = span.enters.reduce((acc, e) => acc + e, 0);
+  const allExits = span.exits.reduce((acc, e) => acc + e.timestamp, 0);
+  const allEnters = span.enters.reduce((acc, e) => acc + e.timestamp, 0);
 
-  const slices = span.enters.map((enter, i) => {
-    const width = scaleToMax([span.exits[i] - enter], allExits - allEnters)[0];
-    const offset = scaleNumbers([enter], span.createdAt, span.closedAt)[0];
+  return span.enters.map((entered, i) => {
+    const exited = span.exits[i].timestamp;
+
+    const width = scaleToMax([exited - entered.timestamp], allExits - allEnters)[0];
+    const offset = scaleNumbers([entered.timestamp], span.createdAt, span.closedAt)[0];
     const marginLeft = offset - (offset * width) / 100;
-    return {
-      width,
-      marginLeft,
-    };
-  });
 
-  return slices.map(
-    (slice) => `width:${slice.width}%;margin-left:${slice.marginLeft}%;`
-  );
+    return {
+      entered: entered.timestamp,
+      exited,
+      busy: width,
+      threadID: entered.threadID,
+      width,
+      marginLeft
+    }
+  })
 }

--- a/web-client/src/lib/span/normalize-spans.ts
+++ b/web-client/src/lib/span/normalize-spans.ts
@@ -60,17 +60,23 @@ export function computeSlices(span: Span) {
   return span.enters.map((entered, i) => {
     const exited = span.exits[i].timestamp;
 
-    const width = scaleToMax([exited - entered.timestamp], allExits - allEnters)[0];
-    const offset = scaleNumbers([entered.timestamp], span.createdAt, span.closedAt)[0];
+    const width = scaleToMax(
+      [exited - entered.timestamp],
+      allExits - allEnters
+    )[0];
+    const offset = scaleNumbers(
+      [entered.timestamp],
+      span.createdAt,
+      span.closedAt
+    )[0];
     const marginLeft = offset - (offset * width) / 100;
 
     return {
       entered: entered.timestamp,
       exited,
-      busy: width,
       threadID: entered.threadID,
       width,
-      marginLeft
-    }
-  })
+      marginLeft,
+    };
+  });
 }

--- a/web-client/src/lib/span/update-spans.ts
+++ b/web-client/src/lib/span/update-spans.ts
@@ -31,7 +31,10 @@ export function updatedSpans(currentSpans: Span[], spanEvents: SpanEvent[]) {
           ? convertTimestampToNanoseconds(event.event.enterSpan.at)
           : -1;
         if (span) {
-          span.enters.push({ timestamp: enteredAt, threadID: Number(event.event.enterSpan.threadId) });
+          span.enters.push({
+            timestamp: enteredAt,
+            threadID: Number(event.event.enterSpan.threadId),
+          });
         }
 
         break;
@@ -43,7 +46,10 @@ export function updatedSpans(currentSpans: Span[], spanEvents: SpanEvent[]) {
           ? convertTimestampToNanoseconds(event.event.exitSpan.at)
           : -1;
         if (span) {
-          span.exits.push({ timestamp: exitedAt, threadID: Number(event.event.exitSpan.threadId) });
+          span.exits.push({
+            timestamp: exitedAt,
+            threadID: Number(event.event.exitSpan.threadId),
+          });
         }
         break;
       }

--- a/web-client/src/lib/span/update-spans.ts
+++ b/web-client/src/lib/span/update-spans.ts
@@ -31,7 +31,7 @@ export function updatedSpans(currentSpans: Span[], spanEvents: SpanEvent[]) {
           ? convertTimestampToNanoseconds(event.event.enterSpan.at)
           : -1;
         if (span) {
-          span.enters.push(enteredAt);
+          span.enters.push({ timestamp: enteredAt, threadID: Number(event.event.enterSpan.threadId) });
         }
 
         break;
@@ -43,7 +43,7 @@ export function updatedSpans(currentSpans: Span[], spanEvents: SpanEvent[]) {
           ? convertTimestampToNanoseconds(event.event.exitSpan.at)
           : -1;
         if (span) {
-          span.exits.push(exitedAt);
+          span.exits.push({ timestamp: exitedAt, threadID: Number(event.event.exitSpan.threadId) });
         }
         break;
       }


### PR DESCRIPTION
This PR adds two improvements to the span details view that expand the graphical span visualizations with some hard data.
- The full duration of the span
- When clicking a "work block" (idk what to call this) it will display when work started, when it ended, what thread performed the work and how long it took

## Screenshots

Clicking a "work block" 👇

<img width="887" alt="Screenshot 2023-12-19 at 16 02 01" src="https://github.com/crabnebula-dev/devtools/assets/118265418/a67ac960-b432-4342-8acc-3ec0e33c86c3">

Clicking a span 👇

<img width="887" alt="Screenshot 2023-12-19 at 16 01 56" src="https://github.com/crabnebula-dev/devtools/assets/118265418/4072581f-fcb5-4045-8156-841010311e5e">


