### PR TITLE
fix: calls tab name column bleeding

### DIFF
--- a/web-client/src/components/span/span-list.tsx
+++ b/web-client/src/components/span/span-list.tsx
@@ -118,11 +118,21 @@ export function SpanList() {
                 onClick={() => setSearchParams({ span: String(span.id) })}
                 class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]"
               >
-                <td class="p-1 overflow-x-auto">{span.name}</td>
-                <td class="p-1 overflow-hidden">
+                <td class="p-1 overflow-hidden text-ellipsis" title={span.name}>
+                  {span.name}
+                </td>
+                <td
+                  class="p-1 overflow-hidden text-ellipsis"
+                  title={getTime(new Date(span.initiated))}
+                >
                   {getTime(new Date(span.initiated))}
                 </td>
-                <td class="p-1 overflow-hidden">{span.time.toFixed(2)}ms</td>
+                <td
+                  class="p-1 overflow-hidden text-ellipsis"
+                  title={`${span.time.toFixed(2)} ms`}
+                >
+                  {span.time.toFixed(2)}ms
+                </td>
                 <td class="p-1 relative overflow-hidden">
                   <div class="relative w-[90%]">
                     <div class="bg-gray-800 w-full absolute rounded-sm h-2" />

--- a/web-client/src/components/span/span-list.tsx
+++ b/web-client/src/components/span/span-list.tsx
@@ -118,10 +118,12 @@ export function SpanList() {
                 onClick={() => setSearchParams({ span: String(span.id) })}
                 class="even:bg-nearly-invisible cursor-pointer hover:bg-[#ffffff05] even:hover:bg-[#ffffff10]"
               >
-                <td class="p-1">{span.name}</td>
-                <td class="p-1">{getTime(new Date(span.initiated))}</td>
-                <td class="p-1">{span.time.toFixed(2)}ms</td>
-                <td class="p-1 relative">
+                <td class="p-1 overflow-x-auto">{span.name}</td>
+                <td class="p-1 overflow-hidden">
+                  {getTime(new Date(span.initiated))}
+                </td>
+                <td class="p-1 overflow-hidden">{span.time.toFixed(2)}ms</td>
+                <td class="p-1 relative overflow-hidden">
                   <div class="relative w-[90%]">
                     <div class="bg-gray-800 w-full absolute rounded-sm h-2" />
                     <div


### PR DESCRIPTION
Fixes DT-43

This prevents the name column from overflowing into other columns like this:

![chrome_07Isl6TSaz](https://github.com/crabnebula-dev/devtools/assets/119593300/77518736-30df-4626-8aea-f088c535150b)

After:

![chrome_HYvkcrQ658](https://github.com/crabnebula-dev/devtools/assets/119593300/9c90e11d-03f7-4e7b-9b7b-c8f572116fab)
