### PR TITLE
Fix/file path url encoding

### DIFF
--- a/clients/web/src/components/sources/source-pane.tsx
+++ b/clients/web/src/components/sources/source-pane.tsx
@@ -9,10 +9,10 @@ import { HighlighterLang } from "~/lib/code-highlight";
 
 export function SourcePane() {
   const params = useParams<Record<"source", string>>();
-  const filename = () => decodeFileName(params.source);
+  const filePath = () => decodeFileName(params.source);
   const [searchParams] = useSearchParams();
 
-  const contentType = () => guessContentType(filename());
+  const contentType = () => guessContentType(filePath());
   const sizeHint = () => parseInt(searchParams.sizeHint);
 
   return (
@@ -20,10 +20,10 @@ export function SourcePane() {
       <Suspense fallback={<Loader />}>
         <Show when={contentType()} fallback={<UnknownView path={filePath()} />}>
           {(resolvedContentType) => (
-            <Switch fallback={<UnknownView path={filename()} />}>
+            <Switch fallback={<UnknownView path={filePath()} />}>
               <Match when={resolvedContentType().startsWith("code/")} keyed>
                 <CodeView
-                  path={filename()}
+                  path={filePath()}
                   size={sizeHint()}
                   lang={
                     resolvedContentType().replace(
@@ -35,7 +35,7 @@ export function SourcePane() {
               </Match>
               <Match when={resolvedContentType().startsWith("image/")} keyed>
                 <ImageView
-                  path={params.source}
+                  path={filePath()}
                   size={sizeHint()}
                   type={resolvedContentType().replace("image/", "")}
                 />

--- a/clients/web/src/components/sources/source-pane.tsx
+++ b/clients/web/src/components/sources/source-pane.tsx
@@ -18,7 +18,7 @@ export function SourcePane() {
   return (
     <Show when={params.source} keyed>
       <Suspense fallback={<Loader />}>
-        <Show when={contentType()}>
+        <Show when={contentType()} fallback={<UnknownView path={filePath()} />}>
           {(resolvedContentType) => (
             <Switch fallback={<UnknownView path={filename()} />}>
               <Match when={resolvedContentType().startsWith("code/")} keyed>

--- a/clients/web/src/lib/sources/file-entries.ts
+++ b/clients/web/src/lib/sources/file-entries.ts
@@ -4,7 +4,10 @@ import { Entry } from "~/lib/proto/sources.ts";
 import { RpcOutputStream } from "@protobuf-ts/runtime-rpc";
 import { Chunk } from "~/lib/proto/sources.ts";
 
-// In the following we "invented" the escape code %DDD to properly escape dots
+/**
+ * Browsers and Routers decode URLs. Since a filename is a piece of a URL, this is breaking our decoding.
+ * So we come up with a stamp (`%DDD`) to allow our sanitization to work without getting confused
+ **/
 
 export function encodeFileName(path: string) {
   return encodeURIComponent(path.replaceAll(".", "%DDD"));

--- a/clients/web/src/lib/sources/file-entries.ts
+++ b/clients/web/src/lib/sources/file-entries.ts
@@ -4,12 +4,14 @@ import { Entry } from "~/lib/proto/sources.ts";
 import { RpcOutputStream } from "@protobuf-ts/runtime-rpc";
 import { Chunk } from "~/lib/proto/sources.ts";
 
+// In the following we "invented" the escape code %DDD to properly escape dots
+
 export function encodeFileName(path: string) {
-  return path.replaceAll(".", "-");
+  return encodeURIComponent(path.replaceAll(".", "%DDD"));
 }
 
 export function decodeFileName(path: string) {
-  return path.replaceAll("-", ".");
+  return decodeURIComponent(path).replaceAll("%DDD", ".");
 }
 
 export function awaitEntries(client: SourcesClient, path: string) {


### PR DESCRIPTION
This fixes the lingering bug from here:
https://linear.app/crabnebula/issue/DT-53/sources-tab-shoud-be-able-to-handle-file-names-containing-

The implementation of  escaping `.` was not quite right yet. Since there is no proper way to escape them, I simply "invented" the escape code `%DDD` to replace the dots. 

(Strictly speaking there is the code `%2E` for `.` the problem with that one is, that solid router just changes it back to a `.` and Chrome for example also acts weird with it)

Added some URL encoding as well to make sure the rest does not break the URL. 

I also noticed that accessing nested files was broken in the previous implementation. As a side effect that is fixed as well.

Furthermore the Unknown View was not properly showing for types that were not in our list at all. A fix for that is included.



Resolves DT-53

