### PR TITLE
fix: property access on undefined exit span

### DIFF
--- a/clients/web/src/lib/span/normalize-spans.ts
+++ b/clients/web/src/lib/span/normalize-spans.ts
@@ -58,7 +58,7 @@ export function computeSlices(span: Span) {
   const allEnters = span.enters.reduce((acc, e) => acc + e.timestamp, 0);
 
   return span.enters.map((entered, i) => {
-    const exited = span.exits[i].timestamp;
+    const exited = span.exits[i]?.timestamp;
 
     const width = scaleToMax(
       [exited - entered.timestamp],


### PR DESCRIPTION
This basically fixes the error getting thrown on spans that don't have an exit yet.

Even though I have to say that the underlying code is really wonky in the first place (I added the question mark to "restore the original behavior":

The original line looked like this:

```typescript
const width = scaleToMax([span.exits[i] - enter], allExits - allEnters)[0];
```

If we the span.exits array is empty it will pretty much resolve to something like:

```typescript
undefined - number = NaN
```

And then it will
```typescript
scaleToMax(NaN, number);
// -> 
(NaN / number) * 100 = NaN
```
Which looks hella ugly and should be revised in the future but does not throw an error.

The updated code:

```typescript
const exited = span.exits[i]?.timestamp;

const width = scaleToMax(
    [exited - entered.timestamp],
    allExits - allEnters
)[0];
```
Knowing that exits can be empty it is easy to spot the previous error. When exits are empty we call the property `.timestamp` on  undefined which is not allowed.

