### PR TITLE
fix: remove weird outline around buttons

### DIFF
--- a/website/src/components/LinkButton.astro
+++ b/website/src/components/LinkButton.astro
@@ -19,7 +19,7 @@ switch (type) {
 <a
   class:list={[
     className,
-    "relative flex items-center gap-2 text-sm md:text-base border-2 rounded-full py-2 px-2 md:px-4",
+    "relative flex items-center gap-2 text-sm md:text-base border-2 rounded-full py-2 px-2 md:px-4 outline-none",
   ]}
   href={href}
 >


### PR DESCRIPTION
This removes the weird way too big `outline` around buttons on the website, by simply disabling them.

I'm not 100% sure what caused this behaviour, but I suspect it is related to the background image trick we do for the hover effect

resolves DT-66