### PR TITLE
revert vite-plugin-static-copy

### DIFF
--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.2.2",
     "vite": "^4.5.0",
     "vite-plugin-solid": "^2.7.2",
-    "vite-plugin-static-copy": "^1.0.0",
+    "vite-plugin-static-copy": "^0.17.0",
     "vite-plugin-wasm": "^3.2.2",
     "vitest": "^0.34.0"
   },

--- a/clients/web/pnpm-lock.yaml
+++ b/clients/web/pnpm-lock.yaml
@@ -128,8 +128,8 @@ devDependencies:
     specifier: ^2.7.2
     version: 2.7.2(solid-js@1.8.7)(vite@4.5.0)
   vite-plugin-static-copy:
-    specifier: ^1.0.0
-    version: 1.0.0(vite@4.5.0)
+    specifier: ^0.17.0
+    version: 0.17.1(vite@4.5.0)
   vite-plugin-wasm:
     specifier: ^3.2.2
     version: 3.2.2(vite@4.5.0)
@@ -4713,11 +4713,11 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-static-copy@1.0.0(vite@4.5.0):
-    resolution: {integrity: sha512-kMlrB3WDtC5GzFedNIPkpjnOAr8M11PfWOiUaONrUZ3AqogTsOmIhTt6w7Fh311wl8pN81ld7sfuOEogFJ9N8A==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  /vite-plugin-static-copy@0.17.1(vite@4.5.0):
+    resolution: {integrity: sha512-9h3iaVs0bqnqZOM5YHJXGHqdC5VAVlTZ2ARYsuNpzhEJUHmFqXY7dAK4ZFpjEQ4WLFKcaN8yWbczr81n01U4sQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^5.0.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
       chokidar: 3.5.3
       fast-glob: 3.3.2


### PR DESCRIPTION
`vite-plugin-static-copy` 1.0.0 drops support for Vite 4.
![](https://github.com/crabnebula-dev/devtools/assets/141120083/c0be2a1e-108f-4326-ba99-c9c5e10982dd)
