### PR TITLE
feat: report the number of dropped events to sentry

### DIFF
--- a/clients/web/src/lib/connection/transport.tsx
+++ b/clients/web/src/lib/connection/transport.tsx
@@ -112,9 +112,12 @@ export function addStreamListneners(
     const logsUpdate = update.logsUpdate;
     if (logsUpdate && logsUpdate.logEvents.length > 0) {
       setMonitorData("logs", (prev) => [...prev, ...logsUpdate.logEvents]);
-      Sentry.setMeasurement("droppedLogEvents", Number(logsUpdate.droppedEvents), 'none');
+      Sentry.setMeasurement(
+        "droppedLogEvents",
+        Number(logsUpdate.droppedEvents),
+        "none"
+      );
     }
-
 
     const spansUpdate = update.spansUpdate;
     if (spansUpdate && spansUpdate.spanEvents.length > 0) {
@@ -124,7 +127,11 @@ export function addStreamListneners(
           updatedSpans(clonedSpans, spansUpdate.spanEvents)
         )
       );
-      Sentry.setMeasurement("droppedSpanEvents", Number(spansUpdate.droppedEvents), 'none');
+      Sentry.setMeasurement(
+        "droppedSpanEvents",
+        Number(spansUpdate.droppedEvents),
+        "none"
+      );
     }
   });
 }

--- a/clients/web/src/lib/connection/transport.tsx
+++ b/clients/web/src/lib/connection/transport.tsx
@@ -13,6 +13,7 @@ import { InstrumentRequest } from "../proto/instrument";
 import { updateSpanMetadata } from "../span/update-span-metadata";
 import { updatedSpans } from "../span/update-spans";
 import { MonitorData } from "./monitor";
+import * as Sentry from "@sentry/browser";
 
 export async function checkConnection(url: string) {
   const abortController = new AbortController();
@@ -111,7 +112,9 @@ export function addStreamListneners(
     const logsUpdate = update.logsUpdate;
     if (logsUpdate && logsUpdate.logEvents.length > 0) {
       setMonitorData("logs", (prev) => [...prev, ...logsUpdate.logEvents]);
+      Sentry.setMeasurement("droppedLogEvents", Number(logsUpdate.droppedEvents), 'none');
     }
+
 
     const spansUpdate = update.spansUpdate;
     if (spansUpdate && spansUpdate.spanEvents.length > 0) {
@@ -121,6 +124,7 @@ export function addStreamListneners(
           updatedSpans(clonedSpans, spansUpdate.spanEvents)
         )
       );
+      Sentry.setMeasurement("droppedSpanEvents", Number(spansUpdate.droppedEvents), 'none');
     }
   });
 }


### PR DESCRIPTION
This is just a two-line change that forwards the number of spans/events the rust instrumentation had to drop bc it was running out of buffer space. This is helpful for us to tweak the internal settings and important for end users since dropped events equal data loss and that is a bad experience all around.