### PR TITLE
Fix: CSP is blocking our gRPC connection

### DIFF
--- a/clients/web/csp.js
+++ b/clients/web/csp.js
@@ -10,7 +10,7 @@ export function generateCSP(isDev = false) {
       "frame-src": [SELF],
       "script-src": isDev ? [SELF, UNSAFE_EVAL] : [SELF],
       "style-src": isDev ? [SELF, UNSAFE_INLINE] : [SELF],
-      "connect-src": [SELF, "127.0.0.1", "ws://localhost:5173/"],
+      "connect-src": [SELF, "127.0.0.1", "127.0.0.1:*", "ws://localhost:5173/"],
       "img-src": [SELF],
       "object-src": [NONE],
     },


### PR DESCRIPTION
This allow any PORT in localhost since the web-client has no control over at which port the gRPC will be serving from.