### PR TITLE
feat: Reenable sentry default integrations for better error handling

### DIFF
--- a/clients/web/src/render-client.tsx
+++ b/clients/web/src/render-client.tsx
@@ -8,8 +8,8 @@ if (!DEV) {
   Sentry.init({
     dsn: "https://57614e75ac5f8c480aed3a2dd1528f13@o4506303762464768.ingest.sentry.io/4506303812272128",
     tunnel: "/sentry-tunnel",
-    integrations: [new Sentry.BrowserTracing()],
-    tracesSampleRate: 0,
+    integrations: (def) => [...def, Sentry.browserTracingIntegration()],
+    tracesSampleRate: 0.1
   });
 }
 


### PR DESCRIPTION
This updates how we configure sentry, reenabling the default integrations that were previously disabled and enabled the reporting of trace samples

closes DT-95