### PR TITLE
Fix/tauri tab configuration loading

### DIFF
--- a/clients/web/src/components/health-status.tsx
+++ b/clients/web/src/components/health-status.tsx
@@ -2,7 +2,7 @@ import { HealthCheckResponse_ServingStatus } from "~/lib/proto/health";
 import { Show, createEffect, createSignal, onMount } from "solid-js";
 import { ErrorDialog } from "./dialogs/error-dialog";
 import {
-  addStreamListneners,
+  addStreamListeners,
   connect,
   checkConnection,
 } from "~/lib/connection/transport";
@@ -121,7 +121,7 @@ export function HealthStatus() {
     setMonitorData("spans", reconcile([]));
     const newConnection = connect(connectionStore.serviceUrl);
     setConnection(reconcile(newConnection, { merge: false }));
-    addStreamListneners(connectionStore.stream.update, setMonitorData);
+    addStreamListeners(connectionStore.stream.update, setMonitorData);
     connectionStore.stream.health.responses.onError(healthErrorHandler);
     connectionStore.stream.update.responses.onError(updateErrorHandler);
   }

--- a/clients/web/src/components/tauri/configuration-context.tsx
+++ b/clients/web/src/components/tauri/configuration-context.tsx
@@ -4,8 +4,6 @@ import {
   useContext,
   type JSXElement,
 } from "solid-js";
-import { type ConfigurationStore } from "~/lib/tauri/config/retrieve-configurations";
-import { createStore } from "solid-js/store";
 
 type ConfigurationContextType = ReturnType<typeof makeConfigurationContext>;
 const ConfigurationContext = createContext<ConfigurationContextType>();
@@ -24,7 +22,6 @@ export const makeConfigurationContext = () => {
   const [descriptions, setDescriptions] = createSignal<
     Map<string, { default?: string }>
   >(new Map());
-  const [configurations, setConfigurations] = createStore<ConfigurationStore>();
   return {
     highlightKey: {
       highlightKey: highlightKey,
@@ -33,10 +30,6 @@ export const makeConfigurationContext = () => {
     descriptions: {
       descriptions: descriptions,
       setDescriptions: setDescriptions,
-    },
-    configurations: {
-      configurations: configurations,
-      setConfigurations: setConfigurations,
     },
   } as const;
 };

--- a/clients/web/src/components/tauri/configuration-view.tsx
+++ b/clients/web/src/components/tauri/configuration-view.tsx
@@ -9,6 +9,7 @@ import { MissingConfigurationParameterDialog } from "./dialogs/missing-configura
 import { MissingConfigurationDialog } from "./dialogs/missing-configuration-dialog";
 import { Heading } from "../heading";
 import { TauriConfig } from "~/lib/tauri/config/tauri-conf";
+import { createMemo } from "solid-js";
 
 export function ConfigurationView() {
   const params = useParams<{
@@ -23,17 +24,24 @@ export function ConfigurationView() {
 
   const config = () => retrieveConfigurationByKey(params.config);
 
-  const tab = () => {
+  const tab = createMemo(() => {
     const config = retrieveConfigurationByKey(params.config);
-    if (config && config.data && config.data[params.selected])
+    if (
+      config &&
+      config.data &&
+      (config.data[params.selected] ||
+        typeof config.data[params.selected] === "string")
+    )
       return config.data[params.selected];
     return undefined;
-  };
+  });
 
-  const tabWithKeys = (currentTab: ReturnType<typeof tab>) => {
+  const tabWithKeys = createMemo(() => {
+    const currentTab = tab();
+    if (typeof currentTab === "string" && currentTab === "") return "empty";
     if (!currentTab || !(Object.keys(currentTab).length > 0)) return undefined;
     return currentTab;
-  };
+  });
 
   createEffect(() => {
     const data = tab();
@@ -55,7 +63,7 @@ export function ConfigurationView() {
           <h1 class="text-3xl">{config()?.label}</h1>
           <ConfigurationErrors error={config()?.error} />
         </Match>
-        <Match when={tabWithKeys(tab())}>
+        <Match when={tabWithKeys()}>
           {(t) => (
             <>
               <header>

--- a/clients/web/src/components/tauri/configuration-view.tsx
+++ b/clients/web/src/components/tauri/configuration-view.tsx
@@ -8,6 +8,7 @@ import { ConfigurationErrors } from "./configuration-errors";
 import { MissingConfigurationParameterDialog } from "./dialogs/missing-configuration-parameter-dialog";
 import { MissingConfigurationDialog } from "./dialogs/missing-configuration-dialog";
 import { Heading } from "../heading";
+import { TauriConfig } from "~/lib/tauri/config/tauri-conf";
 
 export function ConfigurationView() {
   const params = useParams<{
@@ -17,7 +18,7 @@ export function ConfigurationView() {
       | "tauri.windows.conf"
       | "tauri.linux.conf"
       | "tauri.macos.conf";
-    selected: "build" | "package" | "plugins" | "tauri";
+    selected: keyof TauriConfig;
   }>();
 
   const config = () => retrieveConfigurationByKey(params.config);

--- a/clients/web/src/components/tauri/sidebar.tsx
+++ b/clients/web/src/components/tauri/sidebar.tsx
@@ -1,21 +1,21 @@
 import { For, Suspense, Show } from "solid-js";
 import { FileIcon } from "~/components/icons/ide-icons";
 import { A } from "@solidjs/router";
-import {
-  type ConfigurationObject,
-  retrieveConfigurations,
-} from "~/lib/tauri/config/retrieve-configurations";
+import { type ConfigurationObject } from "~/lib/tauri/config/retrieve-configurations";
 import { Loader } from "~/components/loader";
 import { getTauriTabBasePath } from "~/lib/tauri/get-tauri-tab-base-path";
+import { useMonitor } from "~/context/monitor-provider";
 
 export function Sidebar() {
-  const [configEntries] = retrieveConfigurations();
+  const { monitorData } = useMonitor();
 
   return (
     <>
       <h2 class="text-neutral-300 p-4 pb-2 text-2xl">Config</h2>
       <Suspense fallback={<Loader />}>
-        <For each={configEntries()}>{(child) => <Config config={child} />}</For>
+        <For each={monitorData.tauriConfigStore?.configs}>
+          {(child) => <Config config={child} />}
+        </For>
       </Suspense>
     </>
   );

--- a/clients/web/src/lib/connection/monitor.ts
+++ b/clients/web/src/lib/connection/monitor.ts
@@ -6,6 +6,7 @@ import { Timestamp } from "~/lib/proto/google/protobuf/timestamp";
 import { timestampToDate } from "~/lib/formatters";
 import { AppMetadata } from "../proto/meta";
 import { Versions } from "../proto/tauri";
+import { ConfigurationStore } from "../tauri/config/retrieve-configurations";
 
 export type HealthStatus = keyof typeof HealthCheckResponse_ServingStatus;
 
@@ -26,8 +27,10 @@ export type MonitorData = {
   metadata: Map<bigint, Metadata>;
   logs: LogEvent[];
   spans: Span[];
-
+  /** The original/parsed tauri configuration we receive from instrumentation */
   tauriConfig?: Record<"build" | "package" | "plugins" | "tauri", object>;
+  /** All the parsed configurations files we read from the frontend */
+  tauriConfigStore?: ConfigurationStore;
   tauriVersions?: Versions;
   appMetadata?: AppMetadata;
   schema?: object;
@@ -44,7 +47,6 @@ export const initialMonitorData: MonitorData = {
   metadata: new Map(),
   logs: [],
   spans: [],
-
   tauriConfig: undefined,
   tauriVersions: undefined,
   appMetadata: undefined,

--- a/clients/web/src/lib/connection/monitor.ts
+++ b/clients/web/src/lib/connection/monitor.ts
@@ -29,7 +29,7 @@ export type MonitorData = {
   spans: Span[];
   /** The original/parsed tauri configuration we receive from instrumentation */
   tauriConfig?: Record<"build" | "package" | "plugins" | "tauri", object>;
-  /** All the parsed configurations files we read from the frontend */
+  /** All the parsed configuration files we read from the frontend */
   tauriConfigStore?: ConfigurationStore;
   tauriVersions?: Versions;
   appMetadata?: AppMetadata;

--- a/clients/web/src/lib/connection/transport.tsx
+++ b/clients/web/src/lib/connection/transport.tsx
@@ -99,7 +99,7 @@ export function setup(url: string) {
 
 type UpdateStream = ReturnType<typeof connect>["stream"]["update"];
 
-export function addStreamListneners(
+export function addStreamListeners(
   stream: UpdateStream,
   setMonitorData: SetStoreFunction<MonitorData>,
 ) {

--- a/clients/web/src/lib/tauri/config/retrieve-configurations.ts
+++ b/clients/web/src/lib/tauri/config/retrieve-configurations.ts
@@ -1,10 +1,7 @@
-import { createResource, Signal } from "solid-js";
-import { unwrap, reconcile } from "solid-js/store";
 import { getEntryBytes } from "~/lib/sources/file-entries";
 import { bytesToText } from "~/lib/code-highlight";
 import type { SourcesClient } from "~/lib/proto/sources.client";
 import { useConnection } from "~/context/connection-provider";
-import { useConfiguration } from "~/components/tauri/configuration-context";
 import { useMonitor } from "~/context/monitor-provider";
 import { TauriConfig } from "./tauri-conf";
 import {
@@ -15,6 +12,7 @@ import {
 import { zodSchemaForVersion } from "./zod-schema-for-version";
 import { safeStringifyJson, safeParseJson } from "~/lib/safe-json";
 import { z } from "zod";
+import { Versions } from "~/lib/proto/tauri";
 
 export type ConfigurationStore = {
   configs?: ConfigurationObject[];
@@ -38,27 +36,20 @@ export const possibleConfigurationFiles = [
 ];
 
 export function retrieveConfigurationByKey(key: string) {
-  const [configs] = retrieveConfigurations();
-  return configs()?.find((config) => config?.key === key);
-}
-
-export function retrieveConfigurations() {
-  const {
-    configurations: { configurations },
-  } = useConfiguration();
-
-  if (configurations.configs)
-    return createResource(() => configurations.configs);
-
-  return createResource(loadConfigurations, {
-    storage: createDeepConfigurationStoreSignal,
-  });
-}
-
-async function loadConfigurations() {
-  const { connectionStore } = useConnection();
   const { monitorData } = useMonitor();
-  const tauriVersion = monitorData.tauriVersions?.tauri ?? "1";
+  return monitorData.tauriConfigStore?.configs?.find(
+    (config) => config?.key === key,
+  );
+}
+
+export async function loadConfigurations(
+  tauriConfig:
+    | Record<"package" | "plugins" | "tauri" | "build", object>
+    | undefined,
+  tauriVersions: Versions,
+) {
+  const { connectionStore } = useConnection();
+  const tauriVersion = tauriVersions?.tauri ?? "1";
   const zodSchema = zodSchemaForVersion(tauriVersion);
 
   const configurations = (
@@ -69,10 +60,7 @@ async function loadConfigurations() {
     )
   ).filter(notEmpty);
 
-  const loadedConfiguration = parseTauriConfig(
-    monitorData.tauriConfig ?? {},
-    zodSchema,
-  );
+  const loadedConfiguration = parseTauriConfig(tauriConfig ?? {}, zodSchema);
 
   return [
     {
@@ -85,7 +73,7 @@ async function loadConfigurations() {
         isPartiallyValidConfig(loadedConfiguration)
           ? loadedConfiguration.data
           : undefined,
-      raw: safeStringifyJson(monitorData.tauriConfig ?? {}) ?? "",
+      raw: safeStringifyJson(tauriConfig ?? {}) ?? "",
     } satisfies ConfigurationObject,
     ...configurations,
   ];
@@ -129,19 +117,4 @@ async function readListOfConfigurations(
       } satisfies ConfigurationObject;
     }),
   );
-}
-
-function createDeepConfigurationStoreSignal<T>(): Signal<T> {
-  const {
-    configurations: { configurations, setConfigurations },
-  } = useConfiguration();
-  return [
-    () => configurations.configs,
-    (v: T) => {
-      const unwrapped = unwrap(configurations.configs);
-      typeof v === "function" && (v = v(unwrapped));
-      setConfigurations("configs", reconcile(v as ConfigurationObject[]));
-      return configurations.configs;
-    },
-  ] as Signal<T>;
 }

--- a/clients/web/src/lib/tauri/config/tauri-conf-schema-v2-zod.ts
+++ b/clients/web/src/lib/tauri/config/tauri-conf-schema-v2-zod.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 export type TauriConfigV2 = z.infer<typeof tauriConfigSchemaV2>;
+
 export const tauriConfigSchemaV2 = z
   .object({
     $schema: z
@@ -842,6 +843,280 @@ export const tauriConfigSchemaV2 = z
               .describe("The application pattern.")
               .describe("The pattern to use.")
               .default({ use: "brownfield" }),
+            capabilities: z
+              .array(
+                z
+                  .union([
+                    z
+                      .object({
+                        identifier: z
+                          .string()
+                          .describe("Identifier of the capability."),
+                        description: z
+                          .string()
+                          .describe("Description of the capability.")
+                          .default(""),
+                        remote: z
+                          .union([
+                            z
+                              .object({
+                                urls: z
+                                  .array(z.string())
+                                  .describe(
+                                    "Remote domains this capability refers to. Can use glob patterns.",
+                                  ),
+                              })
+                              .describe(
+                                "Configuration for remote URLs that are associated with the capability.",
+                              ),
+                            z.null(),
+                          ])
+                          .describe(
+                            "Configure remote URLs that can use the capability permissions.",
+                          )
+                          .optional(),
+                        local: z
+                          .boolean()
+                          .describe(
+                            "Whether this capability is enabled for local app URLs or not. Defaults to `true`.",
+                          )
+                          .default(true),
+                        windows: z
+                          .array(z.string())
+                          .describe(
+                            "List of windows that uses this capability. Can be a glob pattern.\n\nOn multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.",
+                          ),
+                        webviews: z
+                          .array(z.string())
+                          .describe(
+                            "List of webviews that uses this capability. Can be a glob pattern.\n\nThis is only required when using on multiwebview contexts, by default all child webviews of a window that matches [`Self::windows`] are linked.",
+                          )
+                          .optional(),
+                        permissions: z
+                          .array(
+                            z
+                              .union([
+                                z
+                                  .string()
+                                  .describe(
+                                    "Reference a permission or permission set by identifier.",
+                                  ),
+                                z
+                                  .object({
+                                    identifier: z
+                                      .string()
+                                      .describe(
+                                        "Identifier of the permission or permission set.",
+                                      ),
+                                    allow: z
+                                      .union([
+                                        z
+                                          .array(
+                                            z
+                                              .union([
+                                                z
+                                                  .null()
+                                                  .describe(
+                                                    "Represents a null JSON value.",
+                                                  ),
+                                                z
+                                                  .boolean()
+                                                  .describe(
+                                                    "Represents a [`bool`].",
+                                                  ),
+                                                z
+                                                  .union([
+                                                    z
+                                                      .number()
+                                                      .int()
+                                                      .describe(
+                                                        "Represents an [`i64`].",
+                                                      ),
+                                                    z
+                                                      .number()
+                                                      .describe(
+                                                        "Represents a [`f64`].",
+                                                      ),
+                                                  ])
+                                                  .describe(
+                                                    "A valid ACL number.",
+                                                  )
+                                                  .describe(
+                                                    "Represents a valid ACL [`Number`].",
+                                                  ),
+                                                z
+                                                  .string()
+                                                  .describe(
+                                                    "Represents a [`String`].",
+                                                  ),
+                                                z
+                                                  .array(z.any())
+                                                  .describe(
+                                                    "Represents a list of other [`Value`]s.",
+                                                  ),
+                                                z
+                                                  .record(z.any())
+                                                  .describe(
+                                                    "Represents a map of [`String`] keys to [`Value`]s.",
+                                                  ),
+                                              ])
+                                              .describe(
+                                                "All supported ACL values.",
+                                              ),
+                                          )
+                                          .describe(
+                                            "Data that defines what is allowed by the scope.",
+                                          ),
+                                        z
+                                          .null()
+                                          .describe(
+                                            "Data that defines what is allowed by the scope.",
+                                          ),
+                                      ])
+                                      .describe(
+                                        "Data that defines what is allowed by the scope.",
+                                      )
+                                      .optional(),
+                                    deny: z
+                                      .union([
+                                        z
+                                          .array(
+                                            z
+                                              .union([
+                                                z
+                                                  .null()
+                                                  .describe(
+                                                    "Represents a null JSON value.",
+                                                  ),
+                                                z
+                                                  .boolean()
+                                                  .describe(
+                                                    "Represents a [`bool`].",
+                                                  ),
+                                                z
+                                                  .union([
+                                                    z
+                                                      .number()
+                                                      .int()
+                                                      .describe(
+                                                        "Represents an [`i64`].",
+                                                      ),
+                                                    z
+                                                      .number()
+                                                      .describe(
+                                                        "Represents a [`f64`].",
+                                                      ),
+                                                  ])
+                                                  .describe(
+                                                    "A valid ACL number.",
+                                                  )
+                                                  .describe(
+                                                    "Represents a valid ACL [`Number`].",
+                                                  ),
+                                                z
+                                                  .string()
+                                                  .describe(
+                                                    "Represents a [`String`].",
+                                                  ),
+                                                z
+                                                  .array(z.any())
+                                                  .describe(
+                                                    "Represents a list of other [`Value`]s.",
+                                                  ),
+                                                z
+                                                  .record(z.any())
+                                                  .describe(
+                                                    "Represents a map of [`String`] keys to [`Value`]s.",
+                                                  ),
+                                              ])
+                                              .describe(
+                                                "All supported ACL values.",
+                                              ),
+                                          )
+                                          .describe(
+                                            "Data that defines what is denied by the scope.",
+                                          ),
+                                        z
+                                          .null()
+                                          .describe(
+                                            "Data that defines what is denied by the scope.",
+                                          ),
+                                      ])
+                                      .describe(
+                                        "Data that defines what is denied by the scope.",
+                                      )
+                                      .optional(),
+                                  })
+                                  .describe(
+                                    "Reference a permission or permission set by identifier and extends its scope.",
+                                  ),
+                              ])
+                              .describe(
+                                "An entry for a permission value in a [`Capability`] can be either a raw permission [`Identifier`] or an object that references a permission and extends its scope.",
+                              ),
+                          )
+                          .describe(
+                            "List of permissions attached to this capability. Must include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`.",
+                          ),
+                        platforms: z
+                          .array(
+                            z
+                              .any()
+                              .superRefine((x, ctx) => {
+                                const schemas = [
+                                  z.literal("macOS").describe("MacOS."),
+                                  z.literal("windows").describe("Windows."),
+                                  z.literal("linux").describe("Linux."),
+                                  z.literal("android").describe("Android."),
+                                  z.literal("iOS").describe("iOS."),
+                                ];
+                                const errors = schemas.reduce(
+                                  (errors: z.ZodError[], schema) =>
+                                    ((result) =>
+                                      "error" in result
+                                        ? [...errors, result.error]
+                                        : errors)(schema.safeParse(x)),
+                                  [],
+                                );
+                                if (schemas.length - errors.length !== 1) {
+                                  ctx.addIssue({
+                                    path: ctx.path,
+                                    code: "invalid_union",
+                                    unionErrors: errors,
+                                    message:
+                                      "Invalid input: Should pass single schema",
+                                  });
+                                }
+                              })
+                              .describe("Platform target."),
+                          )
+                          .describe(
+                            "Target platforms this capability applies. By default all platforms are affected by this capability.",
+                          )
+                          .default([
+                            "linux",
+                            "macOS",
+                            "windows",
+                            "android",
+                            "iOS",
+                          ]),
+                      })
+                      .describe(
+                        "a grouping and boundary mechanism developers can use to separate windows or plugins functionality from each other at runtime.\n\nIf a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create trust groups and reduce impact of vulnerabilities in certain plugins or windows. Windows can be added to a capability by exact name or glob patterns like *, admin-* or main-window.",
+                      )
+                      .describe("An inlined capability."),
+                    z
+                      .string()
+                      .describe("Reference to a capability identifier."),
+                  ])
+                  .describe(
+                    "A capability entry which can be either an inlined capability or a reference to a capability defined on its own file.",
+                  ),
+              )
+              .describe(
+                "List of capabilities that are enabled on the application.\n\nIf the list is empty, all capabilities are included.",
+              )
+              .default([]),
           })
           .strict()
           .describe(
@@ -850,6 +1125,7 @@ export const tauriConfigSchemaV2 = z
           .describe("Security configuration.")
           .default({
             assetProtocol: { enable: false, scope: [] },
+            capabilities: [],
             dangerousDisableAssetCspModification: false,
             freezePrototype: false,
             pattern: { use: "brownfield" },
@@ -939,6 +1215,7 @@ export const tauriConfigSchemaV2 = z
         macOSPrivateApi: false,
         security: {
           assetProtocol: { enable: false, scope: [] },
+          capabilities: [],
           dangerousDisableAssetCspModification: false,
           freezePrototype: false,
           pattern: { use: "brownfield" },
@@ -2056,6 +2333,57 @@ export const tauriConfigSchemaV2 = z
                     "Path to a custom desktop file Handlebars template.\n\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.",
                   )
                   .optional(),
+                section: z
+                  .union([
+                    z
+                      .string()
+                      .describe(
+                        "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+                      ),
+                    z
+                      .null()
+                      .describe(
+                        "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+                      ),
+                  ])
+                  .describe(
+                    "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+                  )
+                  .optional(),
+                priority: z
+                  .union([
+                    z
+                      .string()
+                      .describe(
+                        "Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`",
+                      ),
+                    z
+                      .null()
+                      .describe(
+                        "Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`",
+                      ),
+                  ])
+                  .describe(
+                    "Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`",
+                  )
+                  .optional(),
+                changelog: z
+                  .union([
+                    z
+                      .string()
+                      .describe(
+                        "Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+                      ),
+                    z
+                      .null()
+                      .describe(
+                        "Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+                      ),
+                  ])
+                  .describe(
+                    "Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+                  )
+                  .optional(),
               })
               .strict()
               .describe(
@@ -2391,5 +2719,5 @@ export const tauriConfigSchemaV2 = z
   })
   .strict()
   .describe(
-    'The Tauri configuration object. It is read from a file where you can define your frontend assets, configure the bundler and define a tray icon.\n\nThe configuration file is generated by the [`tauri init`](https://tauri.app/v1/api/cli#init) command that lives in your Tauri application source directory (src-tauri).\n\nOnce generated, you may modify it at will to customize your Tauri application.\n\n## File Formats\n\nBy default, the configuration is defined as a JSON file named `tauri.conf.json`.\n\nTauri also supports JSON5 and TOML files via the `config-json5` and `config-toml` Cargo features, respectively. The JSON5 file name must be either `tauri.conf.json` or `tauri.conf.json5`. The TOML file name is `Tauri.toml`.\n\n## Platform-Specific Configuration\n\nIn addition to the default configuration file, Tauri can read a platform-specific configuration from `tauri.linux.conf.json`, `tauri.windows.conf.json`, `tauri.macos.conf.json`, `tauri.android.conf.json` and `tauri.ios.conf.json` (or `Tauri.linux.toml`, `Tauri.windows.toml`, `Tauri.macos.toml`, `Tauri.android.toml` and `Tauri.ios.toml` if the `Tauri.toml` format is used), which gets merged with the main configuration object.\n\n## Configuration Structure\n\nThe configuration is composed of the following objects:\n\n- [`package`](#packageconfig): Package settings - [`app`](#appconfig): The Tauri config - [`build`](#buildconfig): The build configuration - [`plugins`](#pluginconfig): The plugins config\n\n```json title="Example tauri.config.json file" { "productName": "tauri-app", "version": "0.1.0" "build": { "beforeBuildCommand": "", "beforeDevCommand": "", "devUrl": "../dist", "frontendDist": "../dist" }, "app": { "security": { "csp": null }, "windows": [ { "fullscreen": false, "height": 600, "resizable": true, "title": "Tauri App", "width": 800 } ] }, "bundle": {} } ```',
+    'The Tauri configuration object. It is read from a file where you can define your frontend assets, configure the bundler and define a tray icon.\n\nThe configuration file is generated by the [`tauri init`](https://tauri.app/v1/api/cli#init) command that lives in your Tauri application source directory (src-tauri).\n\nOnce generated, you may modify it at will to customize your Tauri application.\n\n## File Formats\n\nBy default, the configuration is defined as a JSON file named `tauri.conf.json`.\n\nTauri also supports JSON5 and TOML files via the `config-json5` and `config-toml` Cargo features, respectively. The JSON5 file name must be either `tauri.conf.json` or `tauri.conf.json5`. The TOML file name is `Tauri.toml`.\n\n## Platform-Specific Configuration\n\nIn addition to the default configuration file, Tauri can read a platform-specific configuration from `tauri.linux.conf.json`, `tauri.windows.conf.json`, `tauri.macos.conf.json`, `tauri.android.conf.json` and `tauri.ios.conf.json` (or `Tauri.linux.toml`, `Tauri.windows.toml`, `Tauri.macos.toml`, `Tauri.android.toml` and `Tauri.ios.toml` if the `Tauri.toml` format is used), which gets merged with the main configuration object.\n\n## Configuration Structure\n\nThe configuration is composed of the following objects:\n\n- [`app`](#appconfig): The Tauri configuration - [`build`](#buildconfig): The build configuration - [`bundle`](#bundleconfig): The bundle configurations - [`plugins`](#pluginconfig): The plugins configuration\n\n```json title="Example tauri.config.json file" { "productName": "tauri-app", "version": "0.1.0" "build": { "beforeBuildCommand": "", "beforeDevCommand": "", "devUrl": "../dist", "frontendDist": "../dist" }, "app": { "security": { "csp": null }, "windows": [ { "fullscreen": false, "height": 600, "resizable": true, "title": "Tauri App", "width": 800 } ] }, "bundle": {}, "plugins": {} } ```',
   );

--- a/clients/web/src/lib/tauri/tauri-conf-lib.ts
+++ b/clients/web/src/lib/tauri/tauri-conf-lib.ts
@@ -4,6 +4,7 @@ import { useMonitor } from "~/context/monitor-provider";
 import { findLineNumberByNestedKeyInSource } from "./find-line-number-by-nested-key-in-source";
 import { retrieveConfigurationByKey } from "./config/retrieve-configurations";
 import { buildSchemaMap } from "./build-schema-map";
+import { TauriConfig } from "./config/tauri-conf";
 
 export function getDescriptionByKey(key: string) {
   const {
@@ -12,7 +13,10 @@ export function getDescriptionByKey(key: string) {
   return descriptions().has(key) ? descriptions().get(key) : undefined;
 }
 
-export function generateDescriptions(key: string, data: object) {
+export function generateDescriptions(
+  key: string,
+  data: TauriConfig[keyof TauriConfig],
+) {
   const { monitorData } = useMonitor();
 
   const {


### PR DESCRIPTION
# Bugfix

This fixes the tauri tab not being compatible with the latest Tauri v2 release and updates the zod schema. 

It moves the configuration loading logic into the `monitor-provider`. This has the advantage that the configuration does not get recomputed every time you access the configuration tab. 

Also fixes a minor bug where top level configuration parameter with an empty string would not be viewable. 

Adds a minor revisit to the `configuration-value` typescript types. (Removes casting and uses proper narrowing instead)

Fixes DT-117