### PR TITLE
Hotfix: console throwing error when filtering while a lot of new logs are coming in

### DIFF
--- a/clients/web/src/components/auto-scroll-pane.tsx
+++ b/clients/web/src/components/auto-scroll-pane.tsx
@@ -74,11 +74,13 @@ export function AutoScrollPane<AutoScrollItem>(
                     queueMicrotask(() => virtualizer.measureElement(el))
                   }
                 >
-                  <props.displayComponent
-                    event={props.dataStream[virtualRow.index]}
-                    {...props.displayOptions}
-                    odd={virtualRow.index & 1}
-                  />
+                  <Show when={props.dataStream[virtualRow.index]}>
+                    <props.displayComponent
+                      event={props.dataStream[virtualRow.index]}
+                      {...props.displayOptions}
+                      odd={virtualRow.index & 1}
+                    />
+                  </Show>
                 </li>
               );
             }}


### PR DESCRIPTION
There seems to be the possibility of the virtualizer not reacting fast enough to a change to the underlying datastream. For example when filtering and thus voiding the datastream it might still want to access a previous index. 

This simple change should prevent the error from occuring.

Fixed DT-119