### PR TITLE
Pin Spellcheck Action Version

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
       - name: Spell Check Repo
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.19.0


### PR DESCRIPTION
To reduce security risks and to improve stability, the spell check action should not point to a moving target (master branch).

I pinned this to the [v1.19.0](https://github.com/crate-ci/typos/tree/v1.19.0) release tag and we need to manually update in case of future releases.