### PR TITLE
fix: sentry tunnel redirect

### DIFF
--- a/clients/web/netlify.toml
+++ b/clients/web/netlify.toml
@@ -2,11 +2,6 @@
 from = "/app/*"
 to = "/:splat"
 
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
-
 # App Sentry redirect.
 [[redirects]]
   from = "/sentry-tunnel/*"
@@ -14,6 +9,10 @@ to = "/:splat"
   status = 200
   headers = { Content-Type = "application/x-sentry-envelope" }
 
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
 
 [build]
     base = "clients/web/"


### PR DESCRIPTION
Just noticed with @tillmann-crabnebula that our redirect rules are eating the redirect for the sentry tunnel. So sentry reporting is not working at the moment :(

This PR should fix that. Fixes DT-122