### PR TITLE
fix: header toml

### DIFF
--- a/clients/web/netlify.toml
+++ b/clients/web/netlify.toml
@@ -21,6 +21,6 @@ to = "/:splat"
 
 [[headers]]
   for = "/*"
-  [[headers.values]]
+  [headers.values]
     X-Frame-Options = "DENY"
     Content-Security-Policy-Report-Only="default-src 'self'; frame-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self' 127.0.0.1 ws://localhost:5173/; img-src 'self'; object-src 'none'; report-uri https://o4506303762464768.ingest.sentry.io/api/4506303812272128/security/?sentry_key=57614e75ac5f8c480aed3a2dd1528f13;"


### PR DESCRIPTION
This fixes our headers definition in the netlify.toml. Could confirm it on the branch deploy:

![chrome_bry7PQJ31g](https://github.com/crabnebula-dev/devtools/assets/119593300/31232a85-14c2-42d7-a73a-0a2e62cc5b09)


Fixes DT-123

