### PR TITLE
fix: remove health stream usage

### DIFF
--- a/clients/web/src/components/health-status.tsx
+++ b/clients/web/src/components/health-status.tsx
@@ -35,16 +35,7 @@ const variant = (status: HealthCheckResponse_ServingStatus) => {
 export function HealthStatus() {
   const updateErrorHandler = () => {
     console.error("an error happened on Updates Stream");
-    // if (isConnectionDead()) {
-    /**
-     * we do nothing because it's not an instrumentation issue.
-     */
-    return;
-    // }
-  };
 
-  const healthErrorHandler = () => {
-    console.error("an error happened on Health Stream");
     setMonitorData("health", 0);
     setConnectionDead(true);
 
@@ -57,7 +48,6 @@ export function HealthStatus() {
         attempts: 5,
       });
   };
-
   /*  undefined = failed to reconnect 
       -1 = reconnecting
       > 0 = time until reconnect 
@@ -139,7 +129,6 @@ export function HealthStatus() {
       monitorData,
     );
 
-    connectionStore.stream.health.responses.onError(healthErrorHandler);
     connectionStore.stream.update.responses.onError(updateErrorHandler);
   }
 
@@ -148,7 +137,6 @@ export function HealthStatus() {
   const [isConnectionDead, setConnectionDead] = createSignal(false);
 
   onMount(() => {
-    connectionStore.stream.health.responses.onError(healthErrorHandler);
     connectionStore.stream.update.responses.onError(updateErrorHandler);
   });
 

--- a/clients/web/src/lib/connection/transport.tsx
+++ b/clients/web/src/lib/connection/transport.tsx
@@ -63,12 +63,6 @@ export function connect(url: string) {
   const sourcesClient = new SourcesClient(transport);
   const metaClient = new MetadataClient(transport);
 
-  const healthStream = healthClient.watch(
-    /**
-     * empty string means all services.
-     */
-    HealthCheckRequest.create({ service: "" }),
-  );
   const updateStream = instrumentClient.watchUpdates(
     InstrumentRequest.create({}),
   );
@@ -84,7 +78,6 @@ export function connect(url: string) {
       meta: metaClient,
     },
     stream: {
-      health: healthStream,
       update: updateStream,
     },
   };


### PR DESCRIPTION
The health watch endpoint is currently broken. Using an empty string for the `service` parameter is supposed to "mean all services" but we actually do not get any messages in that stream. Using an actual service name works fine though. Until we have an actual fix for that, we'll remove the health stream watcher and rely on the instrumentation stream instead.

resolves DT-151