### PR TITLE
feat: shorten log file paths

### DIFF
--- a/clients/web/public/icons/copy.svg
+++ b/clients/web/public/icons/copy.svg
@@ -1,0 +1,5 @@
+<svg preserveAspectRatio="xMidYMid meet" fill="#fff" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+    <title>Copy</title>
+    <path d="M28,10V28H10V10H28m0-2H10a2,2,0,0,0-2,2V28a2,2,0,0,0,2,2H28a2,2,0,0,0,2-2V10a2,2,0,0,0-2-2Z"></path>
+    <path d="M4,18H2V4A2,2,0,0,1,4,2H18V4H4Z"></path>
+</svg>

--- a/clients/web/src/components/console/log-event/field.tsx
+++ b/clients/web/src/components/console/log-event/field.tsx
@@ -1,5 +1,6 @@
 import { Field as IField } from "~/lib/proto/common";
 import { processFieldValue } from "~/lib/span/process-field-value";
+import { shortenLogFilePath, makeBreakable } from "~/lib/formatters";
 
 export function Field(props: { field: IField }) {
   // HACK: overflow isn't handled nicely right now.
@@ -8,8 +9,27 @@ export function Field(props: { field: IField }) {
   const fullStrVal = () => processFieldValue(props.field.value);
   const strVal = () => {
     const val = fullStrVal();
-    if (val.length > maxLen) return val.substring(0, maxLen) + "…";
-    return val;
+    if (/\/|\\/.test(val)) {
+      return (
+        <>
+          {makeBreakable(shortenLogFilePath(val))}
+          <button
+            class="ml-2"
+            onClick={() => navigator.clipboard.writeText(val)}
+            title="copy full path to clipboard"
+          >
+            <img
+              class="h-4 w-4"
+              src="/icons/copy.svg"
+              alt="copy full path to clipboard"
+            />
+          </button>
+        </>
+      );
+    }
+    if (val.length > maxLen)
+      return makeBreakable(val.substring(0, maxLen) + "…");
+    return makeBreakable(val);
   };
 
   return (

--- a/clients/web/src/lib/formatters.ts
+++ b/clients/web/src/lib/formatters.ts
@@ -58,6 +58,17 @@ export function getRootPathByUrlSegment(path: string, segment: string) {
     .join("/");
 }
 
+/** adds zero-width spaces to make entries break-able */
+export function makeBreakable(path: string) {
+  return path.replace(/([_/\\:]+|[^_/\\:]{20})/g, "$1\u200b");
+}
+
 export function shortenFilePath(fullPath: string): string {
   return fullPath.substring(fullPath.lastIndexOf("\\") + 1);
+}
+
+export function shortenLogFilePath(path: string) {
+  const sep = /[/\\]/.exec(path)?.[0] === "\\" ? "\\\\" : "/";
+  const expr = new RegExp(`.*(${sep}.*?${sep}src.*$)`);
+  return path.replace(expr, "…$1");
 }


### PR DESCRIPTION
![shortened-filepath](https://github.com/crabnebula-dev/devtools/assets/165764739/603b5956-b0f9-43aa-87fe-9d63036d3fe8)

Shorten the file path to one directory before the src (if possible) and make all entries word-breakable by inserting zero-width spaces.