### PR TITLE
Hotfix: Accessing undefined exits in traces

### DIFF
--- a/clients/web/src/components/calls/detail-pane/traces/popover/content.tsx
+++ b/clients/web/src/components/calls/detail-pane/traces/popover/content.tsx
@@ -10,7 +10,10 @@ export function Content(props: { span: Span }) {
     span.enters.reduce((acc, enter, i) => {
       const exit = span.exits[i];
 
-      return acc + (exit.timestamp - enter.timestamp);
+      //Don't count enters without exits
+      if (!exit) return acc;
+      const duration = exit.timestamp - enter.timestamp;
+      return acc + duration;
     }, 0);
 
   return (


### PR DESCRIPTION
For internal reference from sentry:
https://crabnebula-ltd.sentry.io/issues/5314877209/?alert_rule_id=14825039&alert_timestamp=1715073935816&alert_type=email&environment=production&notification_uuid=87884c0c-8292-467c-a95a-ad3d7e09a86c&project=4506303812272128&referrer=alert_email

```
TypeError
Cannot read properties of undefined (reading 'timestamp')
```

`../../src/components/calls/detail-pane/traces/popover/content.tsx in reduce at line 13:26`

When a trace is still running it is possible that it has enters without an exit. This case was not handled in the popover content. This PR makes sure that the exit we are trying to access exists. 