### PR TITLE
fix: this readds soft detection (kind only) for spans

### DIFF
--- a/clients/web/src/lib/span/format-span.ts
+++ b/clients/web/src/lib/span/format-span.ts
@@ -4,6 +4,7 @@ import type { Span } from "../connection/monitor";
 import type { SpanEvent_Span } from "../proto/spans";
 import { convertTimestampToNanoseconds } from "../formatters";
 import { IpcData } from "../connection/monitor";
+import { detectKind } from "./update/kinds/detectKind";
 
 export function formatSpan(
   spanEvent: SpanEvent_Span,
@@ -48,5 +49,6 @@ export function formatSpan(
     hasError: null,
   };
 
+  span.kind = detectKind(span);
   return span;
 }

--- a/clients/web/src/lib/span/update/kinds/detectKind.ts
+++ b/clients/web/src/lib/span/update/kinds/detectKind.ts
@@ -1,0 +1,8 @@
+import type { Span } from "~/lib/connection/monitor";
+import { detectEventKind } from "./event/detect-event-kind";
+import { detectIpcKind } from "./ipc/detect-ipc-kind";
+
+export function detectKind(span: Span) {
+  if (detectEventKind(span)) return "event";
+  if (detectIpcKind(span)) return "ipc";
+}

--- a/clients/web/src/lib/span/update/kinds/ipc/detect-ipc-kind.ts
+++ b/clients/web/src/lib/span/update/kinds/ipc/detect-ipc-kind.ts
@@ -1,0 +1,12 @@
+import type { Span } from "~/lib/connection/monitor";
+import { IpcKinds } from "./ipc-spans";
+
+export function detectIpcKind(span: Span) {
+  if (!span.metadata?.name) return;
+
+  for (const ipcKind of IpcKinds) {
+    if (ipcKind.names.has(span.metadata.name)) {
+      return ipcKind.type;
+    }
+  }
+}

--- a/clients/web/src/lib/span/update/kinds/ipc/detect-ipc-trace.ts
+++ b/clients/web/src/lib/span/update/kinds/ipc/detect-ipc-trace.ts
@@ -2,13 +2,12 @@ import type { Span, IpcData } from "~/lib/connection/monitor";
 import { findNamedSpan } from "~/lib/span/find-named-span";
 import { processFieldValue } from "~/lib/span/process-field-value";
 import { getIpcResponse } from "./get-ipc-response";
+import { detectIpcKind } from "./detect-ipc-kind";
 
 // TODO: Revisit this function to see if we can improve on the logic and the eslint disable comments.
 export function detectIpcTrace(root: Span): IpcData | undefined {
-  const ipcNames = ["wry::ipc::handle", "wry::custom_protocol::handle"];
-
   // First we'd like to be sure the root has a specific name.
-  if (!root.metadata?.name || !ipcNames.includes(root.metadata?.name)) return;
+  if (!detectIpcKind(root)) return;
 
   // Then we try to parse a child span with request data.
   const requestSpan = findNamedSpan(root, "tauri::", "ipc::request");

--- a/clients/web/src/lib/span/update/kinds/ipc/ipc-spans.ts
+++ b/clients/web/src/lib/span/update/kinds/ipc/ipc-spans.ts
@@ -1,0 +1,11 @@
+type IpcKind = "ipc";
+
+export const IpcKinds = [
+  {
+    type: "ipc",
+    names: new Set(["wry::ipc::handle", "wry::custom_protocol::handle"]),
+  },
+] as const satisfies {
+  type: IpcKind;
+  names: Set<string>;
+}[];


### PR DESCRIPTION
I noticed that when the `app:setup` root span is still in the buffer. The IPC commands would not get rendered in the calls list.

To prevent this we need to softly/shallowly detect their kind when they get created. 

This PR aims to solve this issue.

Behaviour before:
IPC commands not showing up in calls list when `app:setup` was received from instrumentation

Behaviour after:
IPC commands are still shown but as second level spans