### PR TITLE
Feat: add support for fathom tracking pixel

### DIFF
--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -60,6 +60,7 @@
     "@sentry/browser": "^7.101.0",
     "@sentry/vite-plugin": "^2.14.0",
     "@solid-primitives/map": "^0.4.9",
+    "@solid-primitives/script-loader": "^2.1.2",
     "@solidjs/router": "^0.12.0",
     "@tanstack/solid-virtual": "^3.0.4",
     "clsx": "^2.1.0",

--- a/clients/web/pnpm-lock.yaml
+++ b/clients/web/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   '@solid-primitives/map':
     specifier: ^0.4.9
     version: 0.4.9(solid-js@1.8.14)
+  '@solid-primitives/script-loader':
+    specifier: ^2.1.2
+    version: 2.1.2(solid-js@1.8.14)
   '@solidjs/router':
     specifier: ^0.12.0
     version: 0.12.0(solid-js@1.8.14)
@@ -1326,6 +1329,14 @@ packages:
       solid-js: ^1.6.12
     dependencies:
       '@solid-primitives/utils': 6.2.1(solid-js@1.8.14)
+      solid-js: 1.8.14
+    dev: false
+
+  /@solid-primitives/script-loader@2.1.2(solid-js@1.8.14):
+    resolution: {integrity: sha512-dIeJ3FWfBAlYZzQ0XLpv1ukHcTxPYphCURS01Hri18ykb28eCOdYtgn3OVNgYzAvm9y8rW5IoyIMY+JzYD6Fhw==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
       solid-js: 1.8.14
     dev: false
 

--- a/clients/web/src/lib/load-fathom.ts
+++ b/clients/web/src/lib/load-fathom.ts
@@ -1,0 +1,8 @@
+import { createScriptLoader } from "@solid-primitives/script-loader";
+
+export function loadFathom() {
+  const fathomUrl = import.meta.env.VITE_FATHOM_URL;
+  const fathomId = import.meta.env.VITE_FATHOM_ID;
+  if (fathomUrl && fathomId)
+    createScriptLoader({ src: fathomUrl, "data-site": fathomId, defer: true });
+}

--- a/clients/web/src/render-client.tsx
+++ b/clients/web/src/render-client.tsx
@@ -3,6 +3,7 @@ import "~/css/global.css";
 import Entry from "./entry";
 import * as Sentry from "@sentry/browser";
 import { DEV } from "solid-js";
+import { loadFathom } from "./lib/load-fathom";
 
 if (!DEV) {
   Sentry.init({
@@ -11,6 +12,7 @@ if (!DEV) {
     integrations: (def) => [...def, Sentry.browserTracingIntegration()],
     tracesSampleRate: 0.1,
   });
+  loadFathom();
 }
 
 const app = document.getElementById("app");

--- a/clients/web/tsconfig.json
+++ b/clients/web/tsconfig.json
@@ -26,7 +26,7 @@
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
 
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src", "tests"]
 }


### PR DESCRIPTION
This PR adds support to add the privacy friendly [fathom](https://usefathom.com/) tracking pixel.

## ToDos:
- [x] Make sure to add the necessesary `env`-vars to Netlify:
`VITE_FATHOM_URL` and `VITE_FATHOM_ID`

Closes DT-115