### PR TITLE
feat: add safari not support modal

### DIFF
--- a/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
+++ b/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
@@ -18,8 +18,8 @@ export function SafariNotSupportedDialog() {
         DevTools currently does not support the use of Safari. Sadly Safari does
         not allow you to make requests to localhost. More information in our
         docs:{" "}
-        <a href="https://docs.crabnebula.dev/devtools/safari-not-supported/">
-          https://docs.crabnebula.dev/devtools/safari-not-supported/
+        <a href="https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/">
+          https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/
         </a>
       </p>
     </Dialog>

--- a/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
+++ b/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
@@ -15,15 +15,17 @@ export function SafariNotSupportedDialog() {
       defaultOpen={isSafari}
     >
       <p>
-        DevTools currently does not support the use of Safari. Sadly Safari does
-        not allow you to make requests to localhost. More information in our
-        docs:{" "}
-        <a
-          class="break-words"
-          href="https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/"
-        >
-          docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/
-        </a>
+        DevTools Web currently does not support the use of Safari. Sadly Safari
+        does not allow you to make requests to localhost. More information in
+        our docs:{" "}
+        <strong>
+          <a
+            class="break-words underline"
+            href="https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/"
+          >
+            docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/
+          </a>
+        </strong>
       </p>
     </Dialog>
   );

--- a/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
+++ b/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
@@ -21,9 +21,9 @@ export function SafariNotSupportedDialog() {
         <strong>
           <a
             class="break-words underline"
-            href="https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/"
+            href="https://docs.crabnebula.dev/devtools/troubleshoot/broken-connection/#safari-not-supported"
           >
-            docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/
+            docs.crabnebula.dev/devtools/troubleshoot/broken-connection/#safari-not-supported
           </a>
         </strong>
       </p>

--- a/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
+++ b/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
@@ -16,7 +16,11 @@ export function SafariNotSupportedDialog() {
     >
       <p>
         DevTools currently does not support the use of Safari. Sadly Safari does
-        not allow you to make requests to localhost.
+        not allow you to make requests to localhost. More information in our
+        docs:{" "}
+        <a href="https://docs.crabnebula.dev/devtools/safari-not-supported/">
+          https://docs.crabnebula.dev/devtools/safari-not-supported/
+        </a>
       </p>
     </Dialog>
   );

--- a/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
+++ b/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
@@ -1,0 +1,23 @@
+import { Dialog } from "~/base-components/dialog";
+import { AlertDialog } from "@kobalte/core";
+
+export function SafariNotSupportedDialog() {
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+  return (
+    <Dialog
+      title="Safari is not supported"
+      buttons={
+        <AlertDialog.CloseButton class="border border-neutral-400 hover:bg-neutral-800 hover:border-neutral-100 text-white text-lg py-2 px-4 rounded focus:outline-dashed focus:outline-white focus:outline-offset-2">
+          Dismiss
+        </AlertDialog.CloseButton>
+      }
+      defaultOpen={isSafari}
+    >
+      <p>
+        DevTools currently does not support the use of Safari. Sadly Safari does
+        not allow you to make requests to localhost.
+      </p>
+    </Dialog>
+  );
+}

--- a/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
+++ b/clients/web/src/components/dialogs/safari-not-supported-dialog.tsx
@@ -18,8 +18,11 @@ export function SafariNotSupportedDialog() {
         DevTools currently does not support the use of Safari. Sadly Safari does
         not allow you to make requests to localhost. More information in our
         docs:{" "}
-        <a href="https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/">
-          https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/
+        <a
+          class="break-words"
+          href="https://docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/"
+        >
+          docs.crabnebula.dev/devtools/troubleshooting/web/safari-not-supported/
         </a>
       </p>
     </Dialog>

--- a/clients/web/src/views/connect.tsx
+++ b/clients/web/src/views/connect.tsx
@@ -7,7 +7,8 @@ import { checkConnection } from "~/lib/connection/transport";
 import { GithubIcon } from "~/components/icons/github";
 import { ConnectionFailedDialog } from "~/components/dialogs/connection-failed-dialog";
 import { createStore } from "solid-js/store";
-import { createSignal } from "solid-js";
+import { createSignal, DEV, Show } from "solid-js";
+import { SafariNotSupportedDialog } from "~/components/dialogs/safari-not-supported-dialog";
 
 export default function Connect() {
   const navigate = useNavigate();
@@ -134,6 +135,9 @@ export default function Connect() {
         port={connectionStore.port}
         retry={tryToConnect}
       />
+      <Show when={!DEV}>
+        <SafariNotSupportedDialog />
+      </Show>
     </div>
   );
 }


### PR DESCRIPTION
This PR adds a modal that will be displayed to all safari users notifying them that DevTools Web currently does not support safari:

![Screenshot 2024-06-10 at 16 48 37](https://github.com/crabnebula-dev/devtools/assets/119593300/e7bdbe1b-ffbc-4a96-b2b0-fa41aafb1a97)

Closes DT-51