### PR TITLE
Feat/collapse long messages

### DIFF
--- a/clients/web/public/icons/row--collapse.svg
+++ b/clients/web/public/icons/row--collapse.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="#fff">
+  <title>row--collapse</title>
+  <path d="M26,20H6a2,2,0,0,0-2,2v4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2V22A2,2,0,0,0,26,20Zm0,6H6V22H26Z"/>
+  <polygon points="17 7.828 19.586 10.414 21 9 16 4 11 9 12.414 10.414 15 7.828 15 14 4 14 4 16 28 16 28 14 17 14 17 7.828"/>
+</svg>

--- a/clients/web/public/icons/row--expand.svg
+++ b/clients/web/public/icons/row--expand.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="#fff">
+  <title>row--expand</title>
+  <polygon points="4 18 15 18 15 24.172 12.414 21.586 11 23 16 28 21 23 19.586 21.586 17 24.172 17 18 28 18 28 16 4 16 4 18"/>
+  <path d="M26,4H6A2,2,0,0,0,4,6v4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2V6A2,2,0,0,0,26,4Zm0,6H6V6H26Z"/>
+</svg>

--- a/clients/web/public/icons/text--align--center.svg
+++ b/clients/web/public/icons/text--align--center.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="#fff">
+<title>align--center</title>
+<rect x="6" y="6" width="20" height="2"/><rect x="10" y="12" width="12" height="2"/>
+<rect x="6" y="18" width="20" height="2"/><rect x="10" y="24" width="12" height="2"/>
+</svg>

--- a/clients/web/public/icons/text--align--justify.svg
+++ b/clients/web/public/icons/text--align--justify.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" fill="#fff">
+<title>text--align--justify</title>
+<rect x="6" y="6" width="20" height="2"/><rect x="6" y="12" width="20" height="2"/>
+<rect x="6" y="18" width="20" height="2"/><rect x="6" y="24" width="20" height="2"/>
+</svg>

--- a/clients/web/src/components/console/log-event/field.tsx
+++ b/clients/web/src/components/console/log-event/field.tsx
@@ -28,7 +28,7 @@ export function Field(props: { field: IField }) {
       >
         {strVal()}
       </span>
-      <span class="flex flex-row absolute bg-gray-950/75-right-5 -top-2 z-40 p-1 opacity-45 group-hover:opacity-100">
+      <span class="flex flex-row absolute bg-gray-950/75-right-5 -top-2 z-10 p-1 opacity-45 group-hover:opacity-100">
         <Tooltip.Root>
           <Tooltip.Trigger>
             <button
@@ -42,11 +42,13 @@ export function Field(props: { field: IField }) {
               />
             </button>
           </Tooltip.Trigger>
-          <Tooltip.Content class="z-50">
-            <div class="rounded p-2 border border-slate-500 bg-black shadow">
-              Copy full message to clipboard
-            </div>
-          </Tooltip.Content>
+          <Tooltip.Portal>
+            <Tooltip.Content>
+              <div class="rounded p-2 border border-slate-500 bg-black shadow z-50">
+                Copy full message to clipboard
+              </div>
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip.Root>
       </span>
     </span>

--- a/clients/web/src/components/console/log-event/field.tsx
+++ b/clients/web/src/components/console/log-event/field.tsx
@@ -28,7 +28,7 @@ export function Field(props: { field: IField }) {
       >
         {strVal()}
       </span>
-      <span class="flex flex-row absolute bg-gray-950/50 -right-2 -top-4 z-40 p-1 opacity-45 group-hover:opacity-100">
+      <span class="flex flex-row absolute bg-gray-950/75-right-5 -top-2 z-40 p-1 opacity-45 group-hover:opacity-100">
         <Tooltip.Root>
           <Tooltip.Trigger>
             <button

--- a/clients/web/src/components/console/log-event/field.tsx
+++ b/clients/web/src/components/console/log-event/field.tsx
@@ -33,7 +33,7 @@ export function Field(props: { field: IField }) {
   };
 
   return (
-    <span class="group-hover:text-slate-300 text-slate-500 transition-colors hackathon">
+    <span class="group-hover:text-slate-300 min-w-24 text-slate-500 transition-colors hackathon">
       <span class="fname">{props.field.name}</span>
       <span class="fequal"> = </span>
       <span

--- a/clients/web/src/components/console/log-event/field.tsx
+++ b/clients/web/src/components/console/log-event/field.tsx
@@ -28,7 +28,7 @@ export function Field(props: { field: IField }) {
       >
         {strVal()}
       </span>
-      <span class="flex flex-row absolute bg-gray-950/75-right-5 -top-2 z-10 p-1 opacity-45 group-hover:opacity-100">
+      <span class="hidden group-hover:flex flex-row absolute bg-gray-950/75 -right-6 -top-2 z-10 p-1">
         <Tooltip.Root>
           <Tooltip.Trigger>
             <button
@@ -44,7 +44,7 @@ export function Field(props: { field: IField }) {
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content>
-              <div class="rounded p-2 border border-slate-500 bg-black shadow z-50">
+              <div class="rounded p-2 border border-slate-500 bg-black shadow z-50 pointer-events-none">
                 Copy full message to clipboard
               </div>
             </Tooltip.Content>

--- a/clients/web/src/components/console/log-event/field.tsx
+++ b/clients/web/src/components/console/log-event/field.tsx
@@ -1,6 +1,7 @@
 import { Field as IField } from "~/lib/proto/common";
 import { processFieldValue } from "~/lib/span/process-field-value";
 import { shortenLogFilePath, makeBreakable } from "~/lib/formatters";
+import { Tooltip } from "@kobalte/core";
 
 export function Field(props: { field: IField }) {
   // HACK: overflow isn't handled nicely right now.
@@ -10,22 +11,7 @@ export function Field(props: { field: IField }) {
   const strVal = () => {
     const val = fullStrVal();
     if (/\/|\\/.test(val)) {
-      return (
-        <>
-          {makeBreakable(shortenLogFilePath(val))}
-          <button
-            class="ml-2"
-            onClick={() => navigator.clipboard.writeText(val)}
-            title="copy full path to clipboard"
-          >
-            <img
-              class="h-4 w-4"
-              src="/icons/copy.svg"
-              alt="copy full path to clipboard"
-            />
-          </button>
-        </>
-      );
+      return makeBreakable(shortenLogFilePath(val));
     }
     if (val.length > maxLen)
       return makeBreakable(val.substring(0, maxLen) + "…");
@@ -33,7 +19,7 @@ export function Field(props: { field: IField }) {
   };
 
   return (
-    <span class="group-hover:text-slate-300 min-w-24 text-slate-500 transition-colors hackathon">
+    <span class="group-hover:text-slate-300 min-w-24 text-slate-500 transition-colors hackathon relative">
       <span class="fname">{props.field.name}</span>
       <span class="fequal"> = </span>
       <span
@@ -41,6 +27,27 @@ export function Field(props: { field: IField }) {
         title={fullStrVal()}
       >
         {strVal()}
+      </span>
+      <span class="flex flex-row absolute bg-gray-950/50 right-[-0.5rem] top-[-1rem] z-51 p-1 opacity-45 group-hover:opacity-100">
+        <Tooltip.Root>
+          <Tooltip.Trigger>
+            <button
+              onClick={() => navigator.clipboard.writeText(fullStrVal())}
+              aria-label="Copy data to clipboard"
+            >
+              <img
+                class="h-4 w-4"
+                src="/icons/copy.svg"
+                alt="Copy data to clipboard"
+              />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Content class="z-[99]">
+            <div class="rounded p-2 border border-slate-500 bg-black shadow">
+              Copy full message to clipboard
+            </div>
+          </Tooltip.Content>
+        </Tooltip.Root>
       </span>
     </span>
   );

--- a/clients/web/src/components/console/log-event/field.tsx
+++ b/clients/web/src/components/console/log-event/field.tsx
@@ -28,7 +28,7 @@ export function Field(props: { field: IField }) {
       >
         {strVal()}
       </span>
-      <span class="flex flex-row absolute bg-gray-950/50 right-[-0.5rem] top-[-1rem] z-51 p-1 opacity-45 group-hover:opacity-100">
+      <span class="flex flex-row absolute bg-gray-950/50 -right-2 -top-4 z-40 p-1 opacity-45 group-hover:opacity-100">
         <Tooltip.Root>
           <Tooltip.Trigger>
             <button
@@ -42,7 +42,7 @@ export function Field(props: { field: IField }) {
               />
             </button>
           </Tooltip.Trigger>
-          <Tooltip.Content class="z-[99]">
+          <Tooltip.Content class="z-50">
             <div class="rounded p-2 border border-slate-500 bg-black shadow">
               Copy full message to clipboard
             </div>

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -82,39 +82,47 @@ export function Message(props: {
               </Show>
             </span>
             <Show when={overflows() || !collapse()}>
-              <span class="hidden group-hover:block absolute bg-black right-2 top-0 z-51 pl-1 pb-1 ">
+              <span class="hidden absolute bg-black/50 right-[-0.5rem] top-[-1rem] z-51 p-1 group-hover:flex flex-row">
                 <button
                   onClick={() => navigator.clipboard.writeText(message())}
-                  title="copy full message to clipboard"
+                  title="Copy full message to clipboard"
                 >
                   <img
                     class="h-4 w-4"
                     src="/icons/copy.svg"
-                    alt="copy full message to clipboard"
+                    alt="Copy full message to clipboard"
                   />
                 </button>
                 <Show when={untrack(() => /\r|\n|\t|\s\s+/.test(message()))}>
                   <button
                     class="ml-1"
                     onClick={() => setPre(!pre())}
-                    title="toggle show indentation"
+                    title={pre() ? "Hide indentation" : "Show indentation"}
                   >
                     <img
                       class="h-4 w-4"
-                      src="/icons/code.svg"
-                      alt="toggle show indentation"
+                      src={
+                        pre()
+                          ? "/icons/text--align--justify.svg"
+                          : "/icons/text--align--center.svg"
+                      }
+                      alt={pre() ? "Hide indentation" : "Show indentation"}
                     />
                   </button>
                 </Show>
                 <button
                   class="ml-1"
                   onClick={() => setCollapse(!collapse())}
-                  title="toggle collapse entry"
+                  title={collapse() ? "Row expand" : "Row collapse"}
                 >
                   <img
                     class="h-4 w-4"
-                    src="/icons/code.svg"
-                    alt="toggle collapse entry"
+                    src={
+                      collapse()
+                        ? "/icons/row--expand.svg"
+                        : "/icons/row--collapse.svg"
+                    }
+                    alt={collapse() ? "Row expand" : "Row collapse"}
                   />
                 </button>
               </span>

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -1,5 +1,12 @@
 import type { ProcessedLogEvent } from "~/lib/console/process-log-event-for-view";
-import { Show } from "solid-js";
+import {
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+  untrack,
+} from "solid-js";
 import { A } from "@solidjs/router";
 import MigrateAlt from "~/components/icons/migrate--alt";
 import { useConnection } from "~/context/connection-provider";
@@ -9,9 +16,28 @@ export function Message(props: {
   processedEvent: ProcessedLogEvent;
   showLinks: boolean | undefined;
 }) {
+  const [ref, setRef] = createSignal<HTMLSpanElement>();
+  const [overflows, setOverflows] = createSignal(false);
+  const [collapse, setCollapse] = createSignal(true);
+  const [pre, setPre] = createSignal(false);
+
+  onMount(() => {
+    const measure = () =>
+      setOverflows(
+        (ref()?.offsetHeight || 0) > (ref()?.parentElement?.offsetHeight || 0),
+      );
+    measure();
+    window.addEventListener("resize", measure);
+    onCleanup(() => {
+      window.removeEventListener("resize", measure);
+    });
+  });
+
   const {
     connectionStore: { host, port },
   } = useConnection();
+
+  const message = createMemo(() => props.processedEvent.message);
 
   return (
     <Show when={props.processedEvent.message.length}>
@@ -27,27 +53,74 @@ export function Message(props: {
           </A>
         </Show>
         <span
-          style="block-overflow: ellipsis"
-          class="line-clamp-3 max-h-16"
-          title={props.processedEvent.message}
+          classList={{
+            "group block max-h-[60px]": true,
+            "overflow-hidden": collapse(),
+          }}
         >
-          {makeBreakable(props.processedEvent.message, 150)}
-        </span>
-        <Show when={props.processedEvent.message.length > 50}>
-          <button
-            class="ml-2"
-            onClick={() =>
-              navigator.clipboard.writeText(props.processedEvent.message)
-            }
-            title="copy full message to clipboard"
+          <span
+            classList={{
+              [`block relative bg-black z-50
+                before:shadow-[0_0_1rem_rgba(255,255,255,0.2)]
+                before:absolute before:rounded-lg
+                before:bg-black before:left-[-1rem]
+                before:top-[-1rem] before:right-[-1rem]
+                before:bottom-[-1rem] before:z-0 before:pointer-events-none`]:
+                !collapse(),
+              "whitespace-pre-wrap": pre(),
+            }}
+            title={message()}
+            ref={setRef}
           >
-            <img
-              class="h-4 w-4"
-              src="/icons/copy.svg"
-              alt="copy full message to clipboard"
-            />
-          </button>
-        </Show>
+            <span
+              classList={{
+                "block max-h-[50vh] overflow-auto relative": !collapse(),
+              }}
+            >
+              <Show when={message().length > 40} fallback={message()}>
+                {makeBreakable(message())}
+              </Show>
+            </span>
+            <Show when={overflows() || !collapse()}>
+              <span class="hidden group-hover:block absolute bg-black right-2 top-0 z-51 pl-1 pb-1 ">
+                <button
+                  onClick={() => navigator.clipboard.writeText(message())}
+                  title="copy full message to clipboard"
+                >
+                  <img
+                    class="h-4 w-4"
+                    src="/icons/copy.svg"
+                    alt="copy full message to clipboard"
+                  />
+                </button>
+                <Show when={untrack(() => /\r|\n|\t|\s\s+/.test(message()))}>
+                  <button
+                    class="ml-1"
+                    onClick={() => setPre(!pre())}
+                    title="toggle show indentation"
+                  >
+                    <img
+                      class="h-4 w-4"
+                      src="/icons/code.svg"
+                      alt="toggle show indentation"
+                    />
+                  </button>
+                </Show>
+                <button
+                  class="ml-1"
+                  onClick={() => setCollapse(!collapse())}
+                  title="toggle collapse entry"
+                >
+                  <img
+                    class="h-4 w-4"
+                    src="/icons/code.svg"
+                    alt="toggle collapse entry"
+                  />
+                </button>
+              </span>
+            </Show>
+          </span>
+        </span>
       </span>
     </Show>
   );

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -69,7 +69,7 @@ export function Message(props: {
                 !collapse(),
               "whitespace-pre-wrap": pre(),
             }}
-            title={message()}
+            title={overflows() && collapse() ? message() : undefined}
             ref={setRef}
           >
             <span

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -3,6 +3,7 @@ import { Show } from "solid-js";
 import { A } from "@solidjs/router";
 import MigrateAlt from "~/components/icons/migrate--alt";
 import { useConnection } from "~/context/connection-provider";
+import { makeBreakable } from "~/lib/formatters";
 
 export function Message(props: {
   processedEvent: ProcessedLogEvent;
@@ -25,7 +26,28 @@ export function Message(props: {
             </span>
           </A>
         </Show>
-        {props.processedEvent.message}
+        <span
+          style="block-overflow: ellipsis"
+          class="line-clamp-3 max-h-16"
+          title={props.processedEvent.message}
+        >
+          {makeBreakable(props.processedEvent.message, 150)}
+        </span>
+        <Show when={props.processedEvent.message.length > 50}>
+          <button
+            class="ml-2"
+            onClick={() =>
+              navigator.clipboard.writeText(props.processedEvent.message)
+            }
+            title="copy full message to clipboard"
+          >
+            <img
+              class="h-4 w-4"
+              src="/icons/copy.svg"
+              alt="copy full message to clipboard"
+            />
+          </button>
+        </Show>
       </span>
     </Show>
   );

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -22,6 +22,10 @@ export function Message(props: {
   const [collapse, setCollapse] = createSignal(true);
   const [pre, setPre] = createSignal(false);
 
+  const indentationLabel = () =>
+    pre() ? "Hide indentation" : "Show indentation";
+  const collapseLabel = () => (collapse() ? "Row expand" : "Row collapse");
+
   onMount(() => {
     const measure = () =>
       setOverflows(
@@ -109,9 +113,7 @@ export function Message(props: {
                     <button
                       class="ml-1"
                       onClick={() => setPre(!pre())}
-                      aria-label={
-                        pre() ? "Hide indentation" : "Show indentation"
-                      }
+                      aria-label={indentationLabel()}
                     >
                       <img
                         class="h-4 w-4"
@@ -120,13 +122,13 @@ export function Message(props: {
                             ? "/icons/text--align--justify.svg"
                             : "/icons/text--align--center.svg"
                         }
-                        alt={pre() ? "Hide indentation" : "Show indentation"}
+                        alt={indentationLabel()}
                       />
                     </button>
                   </Tooltip.Trigger>
                   <Tooltip.Content class="z-50">
                     <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                      {pre() ? "Hide indentation" : "Show indentation"}
+                      {indentationLabel()}
                     </div>
                   </Tooltip.Content>
                 </Tooltip.Root>
@@ -137,7 +139,7 @@ export function Message(props: {
                     <button
                       class="ml-1"
                       onClick={() => setCollapse(!collapse())}
-                      aria-label={collapse() ? "Row expand" : "Row collapse"}
+                      aria-label={collapseLabel()}
                     >
                       <img
                         class="h-4 w-4"
@@ -146,13 +148,13 @@ export function Message(props: {
                             ? "/icons/row--expand.svg"
                             : "/icons/row--collapse.svg"
                         }
-                        alt={collapse() ? "Row expand" : "Row collapse"}
+                        alt={collapseLabel()}
                       />
                     </button>
                   </Tooltip.Trigger>
                   <Tooltip.Content class="z-50">
                     <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                      {collapse() ? "Row expand" : "Row collapse"}
+                      {collapseLabel()}
                     </div>
                   </Tooltip.Content>
                 </Tooltip.Root>

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -66,7 +66,7 @@ export function Message(props: {
                 before:border-gray-800 before:border-2
                 before:absolute before:rounded-lg
                 before:bg-gray-950/90 before:left-[-1rem]
-                before:top-[-1rem] before:right-[-1rem]
+                before:-top-4 before:right-[-1rem]
                 before:bottom-[-1rem] before:z-0 before:pointer-events-none`]:
                 !collapse(),
               "whitespace-pre-wrap": pre(),
@@ -83,7 +83,7 @@ export function Message(props: {
               </Show>
             </span>
 
-            <span class="flex flex-row absolute bg-gray-950/50 border-box right-[-0.5rem] top-[-1rem] z-51 p-1 opacity-45 group-hover:opacity-100">
+            <span class="flex flex-row absolute bg-gray-950/50 border-box -right-2 -top-4 z-40 p-1 opacity-45 group-hover:opacity-100">
               <Tooltip.Root>
                 <Tooltip.Trigger>
                   <button
@@ -97,7 +97,7 @@ export function Message(props: {
                     />
                   </button>
                 </Tooltip.Trigger>
-                <Tooltip.Content class="z-[99]">
+                <Tooltip.Content class="z-50">
                   <div class="rounded p-2 border border-slate-500 bg-black shadow">
                     Copy full message to clipboard
                   </div>
@@ -124,7 +124,7 @@ export function Message(props: {
                       />
                     </button>
                   </Tooltip.Trigger>
-                  <Tooltip.Content class="z-[99]">
+                  <Tooltip.Content class="z-50">
                     <div class="rounded p-2 border border-slate-500 bg-black shadow">
                       {pre() ? "Hide indentation" : "Show indentation"}
                     </div>
@@ -150,7 +150,7 @@ export function Message(props: {
                       />
                     </button>
                   </Tooltip.Trigger>
-                  <Tooltip.Content class="z-[99]">
+                  <Tooltip.Content class="z-50">
                     <div class="rounded p-2 border border-slate-500 bg-black shadow">
                       {collapse() ? "Row expand" : "Row collapse"}
                     </div>

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -87,7 +87,7 @@ export function Message(props: {
               </Show>
             </span>
 
-            <span class="flex flex-row absolute bg-gray-950/75 border-box -right-5 -top-2 z-40 p-1 opacity-45 group-hover:opacity-100">
+            <span class="flex flex-row absolute bg-gray-950/75 border-box -right-5 -top-2 z-10 p-1 opacity-45 group-hover:opacity-100">
               <Tooltip.Root>
                 <Tooltip.Trigger>
                   <button
@@ -101,11 +101,13 @@ export function Message(props: {
                     />
                   </button>
                 </Tooltip.Trigger>
-                <Tooltip.Content class="z-50">
-                  <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                    Copy full message to clipboard
-                  </div>
-                </Tooltip.Content>
+                <Tooltip.Portal>
+                  <Tooltip.Content>
+                    <div class="rounded p-2 border border-slate-500 bg-black shadow relative z-50">
+                      Copy full message to clipboard
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Portal>
               </Tooltip.Root>
               <Show when={untrack(() => /\r|\n|\t|\s\s+/.test(message()))}>
                 <Tooltip.Root>
@@ -126,11 +128,13 @@ export function Message(props: {
                       />
                     </button>
                   </Tooltip.Trigger>
-                  <Tooltip.Content class="z-50">
-                    <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                      {indentationLabel()}
-                    </div>
-                  </Tooltip.Content>
+                  <Tooltip.Portal>
+                    <Tooltip.Content>
+                      <div class="rounded p-2 border border-slate-500 bg-black shadow z-50">
+                        {indentationLabel()}
+                      </div>
+                    </Tooltip.Content>
+                  </Tooltip.Portal>
                 </Tooltip.Root>
               </Show>
               <Show when={overflows()}>
@@ -152,11 +156,13 @@ export function Message(props: {
                       />
                     </button>
                   </Tooltip.Trigger>
-                  <Tooltip.Content class="z-50">
-                    <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                      {collapseLabel()}
-                    </div>
-                  </Tooltip.Content>
+                  <Tooltip.Portal>
+                    <Tooltip.Content>
+                      <div class="rounded p-2 border border-slate-500 bg-black shadow z-50">
+                        {collapseLabel()}
+                      </div>
+                    </Tooltip.Content>
+                  </Tooltip.Portal>
                 </Tooltip.Root>
               </Show>
             </span>

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -8,6 +8,7 @@ import {
   untrack,
 } from "solid-js";
 import { A } from "@solidjs/router";
+import { Tooltip } from "@kobalte/core";
 import MigrateAlt from "~/components/icons/migrate--alt";
 import { useConnection } from "~/context/connection-provider";
 import { makeBreakable } from "~/lib/formatters";
@@ -60,16 +61,16 @@ export function Message(props: {
         >
           <span
             classList={{
-              [`block relative bg-black z-50
+              [`block relative z-50
                 before:shadow-[0_0_1rem_rgba(255,255,255,0.2)]
+                before:border-gray-800 before:border-2
                 before:absolute before:rounded-lg
-                before:bg-black before:left-[-1rem]
+                before:bg-gray-950/90 before:left-[-1rem]
                 before:top-[-1rem] before:right-[-1rem]
                 before:bottom-[-1rem] before:z-0 before:pointer-events-none`]:
                 !collapse(),
               "whitespace-pre-wrap": pre(),
             }}
-            title={overflows() && collapse() ? message() : undefined}
             ref={setRef}
           >
             <span
@@ -81,52 +82,82 @@ export function Message(props: {
                 {makeBreakable(message())}
               </Show>
             </span>
-            <Show when={overflows() || !collapse()}>
-              <span class="hidden absolute bg-black/50 right-[-0.5rem] top-[-1rem] z-51 p-1 group-hover:flex flex-row">
-                <button
-                  onClick={() => navigator.clipboard.writeText(message())}
-                  title="Copy full message to clipboard"
-                >
-                  <img
-                    class="h-4 w-4"
-                    src="/icons/copy.svg"
-                    alt="Copy full message to clipboard"
-                  />
-                </button>
-                <Show when={untrack(() => /\r|\n|\t|\s\s+/.test(message()))}>
+
+            <span class="flex flex-row absolute bg-gray-950/50 border-box right-[-0.5rem] top-[-1rem] z-51 p-1 opacity-45 group-hover:opacity-100">
+              <Tooltip.Root>
+                <Tooltip.Trigger>
                   <button
-                    class="ml-1"
-                    onClick={() => setPre(!pre())}
-                    title={pre() ? "Hide indentation" : "Show indentation"}
+                    onClick={() => navigator.clipboard.writeText(message())}
+                    aria-label="Copy full message to clipboard"
                   >
                     <img
                       class="h-4 w-4"
-                      src={
-                        pre()
-                          ? "/icons/text--align--justify.svg"
-                          : "/icons/text--align--center.svg"
-                      }
-                      alt={pre() ? "Hide indentation" : "Show indentation"}
+                      src="/icons/copy.svg"
+                      alt="Copy full message to clipboard"
                     />
                   </button>
-                </Show>
-                <button
-                  class="ml-1"
-                  onClick={() => setCollapse(!collapse())}
-                  title={collapse() ? "Row expand" : "Row collapse"}
-                >
-                  <img
-                    class="h-4 w-4"
-                    src={
-                      collapse()
-                        ? "/icons/row--expand.svg"
-                        : "/icons/row--collapse.svg"
-                    }
-                    alt={collapse() ? "Row expand" : "Row collapse"}
-                  />
-                </button>
-              </span>
-            </Show>
+                </Tooltip.Trigger>
+                <Tooltip.Content class="z-[99]">
+                  <div class="rounded p-2 border border-slate-500 bg-black shadow">
+                    Copy full message to clipboard
+                  </div>
+                </Tooltip.Content>
+              </Tooltip.Root>
+              <Show when={untrack(() => /\r|\n|\t|\s\s+/.test(message()))}>
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="ml-1"
+                      onClick={() => setPre(!pre())}
+                      aria-label={
+                        pre() ? "Hide indentation" : "Show indentation"
+                      }
+                    >
+                      <img
+                        class="h-4 w-4"
+                        src={
+                          pre()
+                            ? "/icons/text--align--justify.svg"
+                            : "/icons/text--align--center.svg"
+                        }
+                        alt={pre() ? "Hide indentation" : "Show indentation"}
+                      />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content class="z-[99]">
+                    <div class="rounded p-2 border border-slate-500 bg-black shadow">
+                      {pre() ? "Hide indentation" : "Show indentation"}
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              </Show>
+              <Show when={overflows()}>
+                <Tooltip.Root>
+                  <Tooltip.Trigger>
+                    <button
+                      class="ml-1"
+                      onClick={() => setCollapse(!collapse())}
+                      aria-label={collapse() ? "Row expand" : "Row collapse"}
+                    >
+                      <img
+                        class="h-4 w-4"
+                        src={
+                          collapse()
+                            ? "/icons/row--expand.svg"
+                            : "/icons/row--collapse.svg"
+                        }
+                        alt={collapse() ? "Row expand" : "Row collapse"}
+                      />
+                    </button>
+                  </Tooltip.Trigger>
+                  <Tooltip.Content class="z-[99]">
+                    <div class="rounded p-2 border border-slate-500 bg-black shadow">
+                      {collapse() ? "Row expand" : "Row collapse"}
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              </Show>
+            </span>
           </span>
         </span>
       </span>

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -87,7 +87,7 @@ export function Message(props: {
               </Show>
             </span>
 
-            <span class="flex flex-row absolute bg-gray-950/75 border-box -right-5 -top-2 z-10 p-1 opacity-45 group-hover:opacity-100">
+            <span class="flex flex-row absolute bg-gray-950/75 border-box -right-3 -top-2 z-10 p-1 opacity-0 group-hover:opacity-100">
               <Tooltip.Root>
                 <Tooltip.Trigger>
                   <button
@@ -103,7 +103,7 @@ export function Message(props: {
                 </Tooltip.Trigger>
                 <Tooltip.Portal>
                   <Tooltip.Content>
-                    <div class="rounded p-2 border border-slate-500 bg-black shadow relative z-50">
+                    <div class="rounded p-2 border border-slate-500 bg-black shadow relative z-50 pointer-events-none">
                       Copy full message to clipboard
                     </div>
                   </Tooltip.Content>
@@ -113,7 +113,7 @@ export function Message(props: {
                 <Tooltip.Root>
                   <Tooltip.Trigger>
                     <button
-                      class="ml-1"
+                      class="mt-1"
                       onClick={() => setPre(!pre())}
                       aria-label={indentationLabel()}
                     >
@@ -130,7 +130,7 @@ export function Message(props: {
                   </Tooltip.Trigger>
                   <Tooltip.Portal>
                     <Tooltip.Content>
-                      <div class="rounded p-2 border border-slate-500 bg-black shadow z-50">
+                      <div class="rounded p-2 border border-slate-500 bg-black shadow z-50 pointer-events-none">
                         {indentationLabel()}
                       </div>
                     </Tooltip.Content>
@@ -141,7 +141,7 @@ export function Message(props: {
                 <Tooltip.Root>
                   <Tooltip.Trigger>
                     <button
-                      class="ml-1"
+                      class="mt-1"
                       onClick={() => setCollapse(!collapse())}
                       aria-label={collapseLabel()}
                     >
@@ -158,7 +158,7 @@ export function Message(props: {
                   </Tooltip.Trigger>
                   <Tooltip.Portal>
                     <Tooltip.Content>
-                      <div class="rounded p-2 border border-slate-500 bg-black shadow z-50">
+                      <div class="rounded p-2 border border-slate-500 bg-black shadow z-50 pointer-events-none">
                         {collapseLabel()}
                       </div>
                     </Tooltip.Content>

--- a/clients/web/src/components/console/log-event/message.tsx
+++ b/clients/web/src/components/console/log-event/message.tsx
@@ -87,7 +87,7 @@ export function Message(props: {
               </Show>
             </span>
 
-            <span class="flex flex-row absolute bg-gray-950/50 border-box -right-2 -top-4 z-40 p-1 opacity-45 group-hover:opacity-100">
+            <span class="flex flex-row absolute bg-gray-950/75 border-box -right-5 -top-2 z-40 p-1 opacity-45 group-hover:opacity-100">
               <Tooltip.Root>
                 <Tooltip.Trigger>
                   <button

--- a/clients/web/src/components/console/log-event/source.tsx
+++ b/clients/web/src/components/console/log-event/source.tsx
@@ -23,12 +23,13 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
     return parentSpan.displayName ?? parentSpan.name;
   });
 
+  const maybeRelativePath = () =>
+    relativePathFromFilePath(props.processedEvent.metadata?.location?.file);
+
   return (
     <MaybeLinkedSource
       class="ml-auto flex gap-2 items-center text-xs relative"
-      maybeRelativePath={relativePathFromFilePath(
-        props.processedEvent.metadata?.location?.file,
-      )}
+      maybeRelativePath={maybeRelativePath()}
       lineNumber={props.processedEvent.metadata?.location?.line}
     >
       <Show when={props.processedEvent.target}>
@@ -49,25 +50,30 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
         when={getFileLineFromLocation(props.processedEvent.metadata?.location)}
       >
         {(line) => (
-          <Tooltip.Root>
-            <Tooltip.Trigger>
-              <span>
-                <span class="flex flex-row absolute bg-gray-950/50 right-[-0.25rem] -top-4 z-40 p-1 opacity-45 group-hover:opacity-100">
-                  <img
-                    src="/icons/code.svg"
-                    class="w-4 h-4"
-                    alt="Jump to code"
-                  />
+          <Show
+            when={maybeRelativePath()}
+            fallback={<span>{shortenFilePath(line())}</span>}
+          >
+            <Tooltip.Root>
+              <Tooltip.Trigger>
+                <span class="flex justify-items-center">
+                  <span class="bg-gray-950/75 p-1 -mt-1 -mb-1 opacity-45 group-hover:opacity-100">
+                    <img
+                      src="/icons/code.svg"
+                      class="w-4 h-4"
+                      alt="Jump to code"
+                    />
+                  </span>
+                  <span>{shortenFilePath(line())}</span>
                 </span>
-                {shortenFilePath(line())}
-              </span>
-            </Tooltip.Trigger>
-            <Tooltip.Content class="z-50">
-              <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                Jump to code: {line()}
-              </div>
-            </Tooltip.Content>
-          </Tooltip.Root>
+              </Tooltip.Trigger>
+              <Tooltip.Content class="z-50">
+                <div class="rounded p-2 border border-slate-500 bg-black shadow">
+                  Jump to code: {line()}
+                </div>
+              </Tooltip.Content>
+            </Tooltip.Root>
+          </Show>
         )}
       </Show>
     </MaybeLinkedSource>

--- a/clients/web/src/components/console/log-event/source.tsx
+++ b/clients/web/src/components/console/log-event/source.tsx
@@ -55,9 +55,7 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
                 <span class="flex flex-row absolute bg-gray-950/50 right-[-0.25rem] -top-4 z-40 p-1 opacity-45 group-hover:opacity-100">
                   <img
                     src="/icons/code.svg"
-                    width="16"
-                    height="16"
-                    class=""
+                    class="w-4 h-4"
                     alt="Jump to code"
                   />
                 </span>

--- a/clients/web/src/components/console/log-event/source.tsx
+++ b/clients/web/src/components/console/log-event/source.tsx
@@ -25,7 +25,7 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
 
   return (
     <MaybeLinkedSource
-      class="ml-auto flex gap-2 items-center text-xs"
+      class="ml-auto flex gap-2 items-center text-xs relative"
       maybeRelativePath={relativePathFromFilePath(
         props.processedEvent.metadata?.location?.file,
       )}
@@ -51,11 +51,22 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
         {(line) => (
           <Tooltip.Root>
             <Tooltip.Trigger>
-              <span>{shortenFilePath(line())}</span>
+              <span>
+                <span class="flex flex-row absolute bg-gray-950/50 right-[-0.25rem] top-[-1rem] z-51 p-1 opacity-45 group-hover:opacity-100">
+                  <img
+                    src="/icons/code.svg"
+                    width="16"
+                    height="16"
+                    class=""
+                    alt="Jump to code"
+                  />
+                </span>
+                {shortenFilePath(line())}
+              </span>
             </Tooltip.Trigger>
-            <Tooltip.Content>
+            <Tooltip.Content class="z-[99]">
               <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                {line()}
+                Jump to code: {line()}
               </div>
             </Tooltip.Content>
           </Tooltip.Root>

--- a/clients/web/src/components/console/log-event/source.tsx
+++ b/clients/web/src/components/console/log-event/source.tsx
@@ -52,7 +52,7 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
           <Tooltip.Root>
             <Tooltip.Trigger>
               <span>
-                <span class="flex flex-row absolute bg-gray-950/50 right-[-0.25rem] top-[-1rem] z-51 p-1 opacity-45 group-hover:opacity-100">
+                <span class="flex flex-row absolute bg-gray-950/50 right-[-0.25rem] -top-4 z-40 p-1 opacity-45 group-hover:opacity-100">
                   <img
                     src="/icons/code.svg"
                     width="16"
@@ -64,7 +64,7 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
                 {shortenFilePath(line())}
               </span>
             </Tooltip.Trigger>
-            <Tooltip.Content class="z-[99]">
+            <Tooltip.Content class="z-50">
               <div class="rounded p-2 border border-slate-500 bg-black shadow">
                 Jump to code: {line()}
               </div>

--- a/clients/web/src/components/console/log-event/source.tsx
+++ b/clients/web/src/components/console/log-event/source.tsx
@@ -67,11 +67,13 @@ export function Source(props: { processedEvent: ProcessedLogEvent }) {
                   <span>{shortenFilePath(line())}</span>
                 </span>
               </Tooltip.Trigger>
-              <Tooltip.Content class="z-50">
-                <div class="rounded p-2 border border-slate-500 bg-black shadow">
-                  Jump to code: {line()}
-                </div>
-              </Tooltip.Content>
+              <Tooltip.Portal>
+                <Tooltip.Content class="z-50">
+                  <div class="rounded p-2 border border-slate-500 bg-black shadow z-50">
+                    Jump to code: {line()}
+                  </div>
+                </Tooltip.Content>
+              </Tooltip.Portal>
             </Tooltip.Root>
           </Show>
         )}

--- a/clients/web/src/components/virtual-list.tsx
+++ b/clients/web/src/components/virtual-list.tsx
@@ -1,4 +1,4 @@
-import { type JSXElement, Show, For, createEffect } from "solid-js";
+import { type JSXElement, Show, For, createEffect, untrack } from "solid-js";
 import { createVirtualizer } from "@tanstack/solid-virtual";
 import clsx from "clsx";
 
@@ -18,7 +18,7 @@ export function VirtualList<VirtualItem>(props: {
     },
     getScrollElement: () => virtualScrollElement ?? null,
     estimateSize: () => props.estimateSize,
-    overscan: props.overscan,
+    overscan: untrack(() => props.overscan),
   });
 
   // Auto scroll on new element effect

--- a/clients/web/src/lib/formatters.ts
+++ b/clients/web/src/lib/formatters.ts
@@ -60,7 +60,7 @@ export function getRootPathByUrlSegment(path: string, segment: string) {
 
 /** adds zero-width spaces to make entries break-able */
 export function makeBreakable(path: string) {
-  return path.replace(/([_/\\:]+|[^_/\\:]{20})/g, "$1\u200b");
+  return path.replace(/([_/\\:]+|[^_/\\:]{20}|[a-z](?:[A-Z]))/g, "$1\u200b");
 }
 
 export function shortenFilePath(fullPath: string): string {

--- a/clients/web/src/views/dashboard/console.tsx
+++ b/clients/web/src/views/dashboard/console.tsx
@@ -1,4 +1,4 @@
-import { createSignal, untrack, For, Setter, Show, createMemo } from "solid-js";
+import { Accessor, createMemo, createSignal, untrack, For, Setter, Show } from "solid-js";
 import { FilterToggle } from "~/components/filter-toggle";
 import { Toolbar } from "~/components/toolbar";
 import { useMonitor } from "~/context/monitor-provider";
@@ -11,21 +11,28 @@ import { VirtualList } from "~/components/virtual-list";
 
 export default function Console() {
   const { monitorData } = useMonitor();
-  const [showAttributes, toggleAttributes] = createSignal(true);
+  const [showAttributes, toggleAttributes] = createSignal(false);
   const [showTimestamp, toggleTimeStamp] = createSignal(true);
   const [shouldAutoScroll, toggleAutoScroll] = createSignal<boolean>(true);
 
-  const filterToggles: { label: string; setter: Setter<boolean> }[] = [
+  const filterToggles: {
+    label: string;
+    getter: Accessor<boolean>;
+    setter: Setter<boolean>;
+  }[] = [
     {
       label: "Attributes",
+      getter: showAttributes,
       setter: toggleAttributes,
     },
     {
       label: "Timestamps",
+      getter: showTimestamp,
       setter: toggleTimeStamp,
     },
     {
       label: "Autoscroll",
+      getter: shouldAutoScroll,
       setter: toggleAutoScroll,
     },
   ];
@@ -66,7 +73,7 @@ export default function Console() {
         <For each={filterToggles}>
           {(filterToggle) => (
             <FilterToggle
-              defaultPressed
+              defaultPressed={filterToggle.getter() || undefined}
               aria-label={filterToggle.label}
               changeHandler={() => filterToggle.setter((prev) => !prev)}
             >

--- a/clients/web/src/views/dashboard/console.tsx
+++ b/clients/web/src/views/dashboard/console.tsx
@@ -1,4 +1,12 @@
-import { Accessor, createMemo, createSignal, untrack, For, Setter, Show } from "solid-js";
+import {
+  Accessor,
+  createMemo,
+  createSignal,
+  untrack,
+  For,
+  Setter,
+  Show,
+} from "solid-js";
 import { FilterToggle } from "~/components/filter-toggle";
 import { Toolbar } from "~/components/toolbar";
 import { useMonitor } from "~/context/monitor-provider";


### PR DESCRIPTION
- Make messages breakable after certain characters or otherwise after 20 characters.
- Cut messages after 3 lines, add uncollapse button
- Adds copy to clipboard button to all message/attributes
- Adds toggle indentation button to messages containing tabs, multiple spaces, or line breaks
- Consolidate icon buttons
- Disable attributes by default
- Bonus: fix linter warning for using props.overscan in a way that inherently untracks

Closes #319 
Closes DT-188