### PR TITLE
fix: autoscroll reactivity

### DIFF
--- a/clients/web/src/components/virtual-list.tsx
+++ b/clients/web/src/components/virtual-list.tsx
@@ -53,14 +53,16 @@ export function VirtualList<VirtualItem>(props: {
     virtualizer.scrollElement?.addEventListener("wheel", checkScrollDirection);
   });
 
-  createEffect(() => {
-    if (
-      autoScrollStarted ||
-      !props.shouldAutoScroll ||
-      !props.dataStream.length
-    )
-      return;
+  const initAutoScroll = (
+    shouldAutoScroll: boolean | undefined,
+    length: number,
+  ) => {
+    if (!shouldAutoScroll || !length || autoScrollStarted) return;
     requestAnimationFrame(autoScroll);
+  };
+
+  createEffect(() => {
+    initAutoScroll(props.shouldAutoScroll, props.dataStream.length);
   });
 
   return (


### PR DESCRIPTION
Solid seems to optimize the if statement in the `createEffect` call, in this case it breaks reactivity for me :/

I rewrote the code to work around this.