### PR TITLE
fix: add the `data-spa` attribute to the fathom script

### DIFF
--- a/clients/web/src/lib/load-fathom.ts
+++ b/clients/web/src/lib/load-fathom.ts
@@ -4,5 +4,10 @@ export function loadFathom() {
   const fathomUrl = import.meta.env.VITE_FATHOM_URL;
   const fathomId = import.meta.env.VITE_FATHOM_ID;
   if (fathomUrl && fathomId)
-    createScriptLoader({ src: fathomUrl, "data-site": fathomId, defer: true });
+    createScriptLoader({
+      src: fathomUrl,
+      "data-site": fathomId,
+      "data-spa": "auto",
+      defer: true,
+    });
 }


### PR DESCRIPTION
TLDR:
Tracking of SPA navigations might have been not working. Tracking of initial page load was not affected.

When working on integrating Fathom for cloud @beanow-at-crabnebula mentioned that the tracking might be off when using the SPA navigation. After looking at the Fathom docs. It seems like it is best to add the `data-spa` attribute for good measure:

https://usefathom.com/docs/script/script-advanced#spa


