### PR TITLE
fix: csp settings

### DIFF
--- a/clients/web/csp.js
+++ b/clients/web/csp.js
@@ -6,8 +6,14 @@ import {
   WASM_UNSAFE_EVAL,
   UNSAFE_EVAL,
 } from "csp-header";
+import { env, argv } from "node:process";
+import { readFile, writeFile } from "node:fs/promises";
 
 export function generateCSP(isDev = false) {
+  const FATHOM_HOST = env.VITE_FATHOM_URL
+    ? new URL(env.VITE_FATHOM_URL).host
+    : undefined;
+
   return getCSP({
     reportUri: isDev
       ? ""
@@ -16,14 +22,27 @@ export function generateCSP(isDev = false) {
       "default-src": [SELF],
       "frame-src": [SELF],
       "script-src": isDev
-        ? [SELF, UNSAFE_EVAL, process.env.VITE_FATHOM_URL]
-        : [SELF, WASM_UNSAFE_EVAL, process.env.VITE_FATHOM_URL],
+        ? [SELF, UNSAFE_EVAL, FATHOM_HOST].filter(Boolean)
+        : [SELF, WASM_UNSAFE_EVAL, FATHOM_HOST].filter(Boolean),
       "style-src": [SELF, UNSAFE_INLINE],
       "connect-src": [SELF, "127.0.0.1", "127.0.0.1:*", "ws://localhost:5173/"],
-      "img-src": [SELF, process.env.VITE_FATHOM_URL],
+      "img-src": [SELF, FATHOM_HOST].filter(Boolean),
       "object-src": [NONE],
     },
   });
 }
 
-console.log(generateCSP());
+if (argv.includes("-i")) {
+  readFile("./netlify.toml", "utf-8").then((toml) =>
+    writeFile(
+      "./netlify.toml",
+      toml.replace(
+        /Content-Security-Policy-Report-Only=[^\n]+/,
+        `Content-Security-Policy-Report-Only="${generateCSP()}"`,
+      ),
+      "utf-8",
+    ).then(() => console.log("Updated CSP headers in netlify.toml")),
+  );
+} else {
+  console.log(generateCSP());
+}

--- a/clients/web/csp.js
+++ b/clients/web/csp.js
@@ -15,10 +15,12 @@ export function generateCSP(isDev = false) {
     directives: {
       "default-src": [SELF],
       "frame-src": [SELF],
-      "script-src": isDev ? [SELF, UNSAFE_EVAL] : [SELF, WASM_UNSAFE_EVAL],
-      "style-src": isDev ? [SELF, UNSAFE_INLINE] : [SELF],
+      "script-src": isDev
+        ? [SELF, UNSAFE_EVAL, process.env.VITE_FATHOM_URL]
+        : [SELF, WASM_UNSAFE_EVAL, process.env.VITE_FATHOM_URL],
+      "style-src": [SELF, UNSAFE_INLINE],
       "connect-src": [SELF, "127.0.0.1", "127.0.0.1:*", "ws://localhost:5173/"],
-      "img-src": [SELF],
+      "img-src": [SELF, process.env.VITE_FATHOM_URL],
       "object-src": [NONE],
     },
   });

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -11,16 +11,8 @@
       id="app"
       class="grid bg-navy-700 bg-opacity-70 grid-rows-[var(--header-height),calc(100vh-calc(var(--header-height)+var(--footer-height))),var(--footer-height)] h-screen"
     ></div>
-    <div
-      style="
-        z-index: -10;
-        position: absolute;
-        inset: 0px;
-        opacity: 0.5;
-        overflow: hidden;
-      "
-    >
-      <img style="width: 100%; height: 100%" src="/bg.webp" aria-hidden />
+    <div class="z-[-10] absolute inset-0 opacity-50 overflow-hidden">
+      <img class="w-full h-full" src="/bg.webp" aria-hidden />
     </div>
     <!-- this one is handled by Vite. No need for subpath-->
     <script type="module" src="/src/render-client.tsx"></script>

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -10,7 +10,6 @@
     "proto": "protoc --ts_out src/lib/proto --proto_path ../../crates/wire/proto ../../crates/wire/proto/common.proto ../../crates/wire/proto/instrument.proto ../../crates/wire/proto/logs.proto ../../crates/wire/proto/spans.proto ../../crates/wire/proto/tauri.proto ../../crates/wire/proto/sources.proto ../../crates/wire/proto/meta.proto ../../crates/wire/proto/health.proto",
     "dev": "pnpm proto --experimental_allow_proto3_optional && vite",
     "build:csp": "node csp.js -i",
-    "prebuild": "node -e \"require('fs/promises').symlink('node_modules/@sentry/cli/bin/sentry-cli', 'node_modules/@sentry/cli/sentry-cli')\"",
     "build": "pnpm proto && vite build",
     "preview": "pnpm proto && vite preview",
     "format": "prettier --write --cache .",
@@ -25,8 +24,6 @@
   },
   "devDependencies": {
     "@protobuf-ts/protoc": "^2.9.4",
-    "@sentry/netlify-build-plugin": "^1.1.1",
-    "@sentry/cli": "^2.46.0",
     "@shikijs/transformers": "^1.12.1",
     "@solidjs/testing-library": "^0.8.9",
     "@testing-library/jest-dom": "^6.4.8",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "proto": "protoc --ts_out src/lib/proto --proto_path ../../crates/wire/proto ../../crates/wire/proto/common.proto ../../crates/wire/proto/instrument.proto ../../crates/wire/proto/logs.proto ../../crates/wire/proto/spans.proto ../../crates/wire/proto/tauri.proto ../../crates/wire/proto/sources.proto ../../crates/wire/proto/meta.proto ../../crates/wire/proto/health.proto",
     "dev": "pnpm proto --experimental_allow_proto3_optional && vite",
-    "build:csp": "node csp.js -i",
+    "prebuild": "node csp.js -i",
     "build": "pnpm proto && vite build",
     "preview": "pnpm proto && vite preview",
     "format": "prettier --write --cache .",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -10,6 +10,7 @@
     "proto": "protoc --ts_out src/lib/proto --proto_path ../../crates/wire/proto ../../crates/wire/proto/common.proto ../../crates/wire/proto/instrument.proto ../../crates/wire/proto/logs.proto ../../crates/wire/proto/spans.proto ../../crates/wire/proto/tauri.proto ../../crates/wire/proto/sources.proto ../../crates/wire/proto/meta.proto ../../crates/wire/proto/health.proto",
     "dev": "pnpm proto --experimental_allow_proto3_optional && vite",
     "build:csp": "node csp.js -i",
+    "prebuild": "node -e \"require('fs/promises').symlink('node_modules/@sentry/cli/bin/sentry-cli', 'node_modules/@sentry/cli/sentry-cli')\"",
     "build": "pnpm proto && vite build",
     "preview": "pnpm proto && vite preview",
     "format": "prettier --write --cache .",
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@protobuf-ts/protoc": "^2.9.4",
     "@sentry/netlify-build-plugin": "^1.1.1",
+    "@sentry/cli": "^2.46.0",
     "@shikijs/transformers": "^1.12.1",
     "@solidjs/testing-library": "^0.8.9",
     "@testing-library/jest-dom": "^6.4.8",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "proto": "protoc --ts_out src/lib/proto --proto_path ../../crates/wire/proto ../../crates/wire/proto/common.proto ../../crates/wire/proto/instrument.proto ../../crates/wire/proto/logs.proto ../../crates/wire/proto/spans.proto ../../crates/wire/proto/tauri.proto ../../crates/wire/proto/sources.proto ../../crates/wire/proto/meta.proto ../../crates/wire/proto/health.proto",
     "dev": "pnpm proto --experimental_allow_proto3_optional && vite",
+    "build:csp": "node csp.js -i",
     "build": "pnpm proto && vite build",
     "preview": "pnpm proto && vite preview",
     "format": "prettier --write --cache .",

--- a/clients/web/pnpm-lock.yaml
+++ b/clients/web/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@protobuf-ts/protoc':
         specifier: ^2.9.4
         version: 2.9.4
+      '@sentry/cli':
+        specifier: ^2.46.0
+        version: 2.46.0
       '@sentry/netlify-build-plugin':
         specifier: ^1.1.1
         version: 1.1.1
@@ -643,43 +646,49 @@ packages:
     resolution: {integrity: sha512-F8FdL/bS8cy1SY1Gw0Mfo3ROTqlrq9Lvt5QGvhXi22dpVcDkWmoTWE2k+sMEnXOa8SdThMc/gyC8lMwHGd3kFQ==}
     engines: {node: '>= 14'}
 
-  '@sentry/cli-darwin@2.33.1':
-    resolution: {integrity: sha512-+4/VIx/E1L2hChj5nGf5MHyEPHUNHJ/HoG5RY+B+vyEutGily1c1+DM2bum7RbD0xs6wKLIyup5F02guzSzG8A==}
+  '@sentry/cli-darwin@2.46.0':
+    resolution: {integrity: sha512-5Ll+e5KAdIk9OYiZO8aifMBRNWmNyPjSqdjaHlBC1Qfh7pE3b1zyzoHlsUazG0bv0sNrSGea8e7kF5wIO1hvyg==}
     engines: {node: '>=10'}
     os: [darwin]
 
-  '@sentry/cli-linux-arm64@2.33.1':
-    resolution: {integrity: sha512-DbGV56PRKOLsAZJX27Jt2uZ11QfQEMmWB4cIvxkKcFVE+LJP4MVA+MGGRUL6p+Bs1R9ZUuGbpKGtj0JiG6CoXw==}
+  '@sentry/cli-linux-arm64@2.46.0':
+    resolution: {integrity: sha512-OEJN8yAjI9y5B4telyqzu27Hi3+S4T8VxZCqJz1+z2Mp0Q/MZ622AahVPpcrVq/5bxrnlZR16+lKh8L1QwNFPg==}
     engines: {node: '>=10'}
     cpu: [arm64]
-    os: [linux, freebsd]
+    os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-arm@2.33.1':
-    resolution: {integrity: sha512-zbxEvQju+tgNvzTOt635le4kS/Fbm2XC2RtYbCTs034Vb8xjrAxLnK0z1bQnStUV8BkeBHtsNVrG+NSQDym2wg==}
+  '@sentry/cli-linux-arm@2.46.0':
+    resolution: {integrity: sha512-WRrLNq/TEX/TNJkGqq6Ad0tGyapd5dwlxtsPbVBrIdryuL1mA7VCBoaHBr3kcwJLsgBHFH0lmkMee2ubNZZdkg==}
     engines: {node: '>=10'}
     cpu: [arm]
-    os: [linux, freebsd]
+    os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-i686@2.33.1':
-    resolution: {integrity: sha512-g2LS4oPXkPWOfKWukKzYp4FnXVRRSwBxhuQ9eSw2peeb58ZIObr4YKGOA/8HJRGkooBJIKGaAR2mH2Pk1TKaiA==}
+  '@sentry/cli-linux-i686@2.46.0':
+    resolution: {integrity: sha512-xko3/BVa4LX8EmRxVOCipV+PwfcK5Xs8lP6lgF+7NeuAHMNL4DqF6iV9rrN8gkGUHCUI9RXSve37uuZnFy55+Q==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
-    os: [linux, freebsd]
+    os: [linux, freebsd, android]
 
-  '@sentry/cli-linux-x64@2.33.1':
-    resolution: {integrity: sha512-IV3dcYV/ZcvO+VGu9U6kuxSdbsV2kzxaBwWUQxtzxJ+cOa7J8Hn1t0koKGtU53JVZNBa06qJWIcqgl4/pCuKIg==}
+  '@sentry/cli-linux-x64@2.46.0':
+    resolution: {integrity: sha512-hJ1g5UEboYcOuRia96LxjJ0jhnmk8EWLDvlGnXLnYHkwy3ree/L7sNgdp/QsY8Z4j2PGO5f22Va+UDhSjhzlfQ==}
     engines: {node: '>=10'}
     cpu: [x64]
-    os: [linux, freebsd]
+    os: [linux, freebsd, android]
 
-  '@sentry/cli-win32-i686@2.33.1':
-    resolution: {integrity: sha512-F7cJySvkpzIu7fnLKNHYwBzZYYwlhoDbAUnaFX0UZCN+5DNp/5LwTp37a5TWOsmCaHMZT4i9IO4SIsnNw16/zQ==}
+  '@sentry/cli-win32-arm64@2.46.0':
+    resolution: {integrity: sha512-mN7cpPoCv2VExFRGHt+IoK11yx4pM4ADZQGEso5BAUZ5duViXB2WrAXCLd8DrwMnP0OE978a7N8OtzsFqjkbNA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.46.0':
+    resolution: {integrity: sha512-6F73AUE3lm71BISUO19OmlnkFD5WVe4/wA1YivtLZTc1RU3eUYJLYxhDfaH3P77+ycDppQ2yCgemLRaA4A8mNQ==}
     engines: {node: '>=10'}
     cpu: [x86, ia32]
     os: [win32]
 
-  '@sentry/cli-win32-x64@2.33.1':
-    resolution: {integrity: sha512-8VyRoJqtb2uQ8/bFRKNuACYZt7r+Xx0k2wXRGTyH05lCjAiVIXn7DiS2BxHFty7M1QEWUCMNsb/UC/x/Cu2wuA==}
+  '@sentry/cli-win32-x64@2.46.0':
+    resolution: {integrity: sha512-yuGVcfepnNL84LGA0GjHzdMIcOzMe0bjPhq/rwPsPN+zu11N+nPR2wV2Bum4U0eQdqYH3iAlMdL5/BEQfuLJww==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -689,8 +698,8 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  '@sentry/cli@2.33.1':
-    resolution: {integrity: sha512-dUlZ4EFh98VFRPJ+f6OW3JEYQ7VvqGNMa0AMcmvk07ePNeK/GicAWmSQE4ZfJTTl80ul6HZw1kY01fGQOQlVRA==}
+  '@sentry/cli@2.46.0':
+    resolution: {integrity: sha512-nqoPl7UCr446QFkylrsRrUXF51x8Z9dGquyf4jaQU+OzbOJMqclnYEvU6iwbwvaw3tu/2DnoZE/Og+Nq1h63sA==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -3322,7 +3331,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@sentry/babel-plugin-component-annotate': 2.21.1
-      '@sentry/cli': 2.33.1
+      '@sentry/cli': 2.46.0
       dotenv: 16.4.5
       find-up: 5.0.0
       glob: 9.3.5
@@ -3332,25 +3341,28 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/cli-darwin@2.33.1':
+  '@sentry/cli-darwin@2.46.0':
     optional: true
 
-  '@sentry/cli-linux-arm64@2.33.1':
+  '@sentry/cli-linux-arm64@2.46.0':
     optional: true
 
-  '@sentry/cli-linux-arm@2.33.1':
+  '@sentry/cli-linux-arm@2.46.0':
     optional: true
 
-  '@sentry/cli-linux-i686@2.33.1':
+  '@sentry/cli-linux-i686@2.46.0':
     optional: true
 
-  '@sentry/cli-linux-x64@2.33.1':
+  '@sentry/cli-linux-x64@2.46.0':
     optional: true
 
-  '@sentry/cli-win32-i686@2.33.1':
+  '@sentry/cli-win32-arm64@2.46.0':
     optional: true
 
-  '@sentry/cli-win32-x64@2.33.1':
+  '@sentry/cli-win32-i686@2.46.0':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.46.0':
     optional: true
 
   '@sentry/cli@1.77.3':
@@ -3365,7 +3377,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/cli@2.33.1':
+  '@sentry/cli@2.46.0':
     dependencies:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
@@ -3373,13 +3385,14 @@ snapshots:
       proxy-from-env: 1.1.0
       which: 2.0.2
     optionalDependencies:
-      '@sentry/cli-darwin': 2.33.1
-      '@sentry/cli-linux-arm': 2.33.1
-      '@sentry/cli-linux-arm64': 2.33.1
-      '@sentry/cli-linux-i686': 2.33.1
-      '@sentry/cli-linux-x64': 2.33.1
-      '@sentry/cli-win32-i686': 2.33.1
-      '@sentry/cli-win32-x64': 2.33.1
+      '@sentry/cli-darwin': 2.46.0
+      '@sentry/cli-linux-arm': 2.46.0
+      '@sentry/cli-linux-arm64': 2.46.0
+      '@sentry/cli-linux-i686': 2.46.0
+      '@sentry/cli-linux-x64': 2.46.0
+      '@sentry/cli-win32-arm64': 2.46.0
+      '@sentry/cli-win32-i686': 2.46.0
+      '@sentry/cli-win32-x64': 2.46.0
     transitivePeerDependencies:
       - encoding
       - supports-color

--- a/clients/web/pnpm-lock.yaml
+++ b/clients/web/pnpm-lock.yaml
@@ -78,12 +78,6 @@ importers:
       '@protobuf-ts/protoc':
         specifier: ^2.9.4
         version: 2.9.4
-      '@sentry/cli':
-        specifier: ^2.46.0
-        version: 2.46.0
-      '@sentry/netlify-build-plugin':
-        specifier: ^1.1.1
-        version: 1.1.1
       '@shikijs/transformers':
         specifier: ^1.12.1
         version: 1.12.1
@@ -693,11 +687,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sentry/cli@1.77.3':
-    resolution: {integrity: sha512-c3eDqcDRmy4TFz2bFU5Y6QatlpoBPPa8cxBooaS4aMQpnIdLYPF1xhyyiW0LQlDUNc3rRjNF7oN5qKoaRoMTQQ==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
   '@sentry/cli@2.46.0':
     resolution: {integrity: sha512-nqoPl7UCr446QFkylrsRrUXF51x8Z9dGquyf4jaQU+OzbOJMqclnYEvU6iwbwvaw3tu/2DnoZE/Og+Nq1h63sA==}
     engines: {node: '>= 10'}
@@ -710,10 +699,6 @@ packages:
   '@sentry/integrations@7.118.0':
     resolution: {integrity: sha512-C2rR4NvIMjokF8jP5qzSf1o2zxDx7IeYnr8u15Kb2+HdZtX559owALR0hfgwnfeElqMhGlJBaKUWZ48lXJMzCQ==}
     engines: {node: '>=8'}
-
-  '@sentry/netlify-build-plugin@1.1.1':
-    resolution: {integrity: sha512-VBMw/sFnRhwvA3p0f3yW3mgnuYIPmoMkaMiwMl/2SptKr7fDqtwMDBsH+LKx2biffFuigSpW+7nV2+L/yEhUmw==}
-    engines: {node: '>=8.12.0'}
 
   '@sentry/replay@7.118.0':
     resolution: {integrity: sha512-boQfCL+1L/tSZ9Huwi00+VtU+Ih1Lcg8HtxBuAsBCJR9pQgUL5jp7ECYdTeeHyCh/RJO7JqV1CEoGTgohe10mA==}
@@ -2013,9 +1998,6 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
@@ -2023,10 +2005,6 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
 
   mlly@1.7.1:
     resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
@@ -3365,18 +3343,6 @@ snapshots:
   '@sentry/cli-win32-x64@2.46.0':
     optional: true
 
-  '@sentry/cli@1.77.3':
-    dependencies:
-      https-proxy-agent: 5.0.1
-      mkdirp: 0.5.6
-      node-fetch: 2.7.0
-      progress: 2.0.3
-      proxy-from-env: 1.1.0
-      which: 2.0.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@sentry/cli@2.46.0':
     dependencies:
       https-proxy-agent: 5.0.1
@@ -3408,13 +3374,6 @@ snapshots:
       '@sentry/types': 7.118.0
       '@sentry/utils': 7.118.0
       localforage: 1.10.0
-
-  '@sentry/netlify-build-plugin@1.1.1':
-    dependencies:
-      '@sentry/cli': 1.77.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   '@sentry/replay@7.118.0':
     dependencies:
@@ -4986,15 +4945,9 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimist@1.2.8: {}
-
   minipass@4.2.8: {}
 
   minipass@7.1.2: {}
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
 
   mlly@1.7.1:
     dependencies:

--- a/clients/web/src/components/calls/detail-pane/traces/popover/tool-tip/row.tsx
+++ b/clients/web/src/components/calls/detail-pane/traces/popover/tool-tip/row.tsx
@@ -3,9 +3,7 @@ import { type JSXElement, Show } from "solid-js";
 export function Row(props: { title: string; children?: JSXElement }) {
   return (
     <tr class="grid grid-cols-2 text-left">
-      <th style={{ "grid-column": props.children ? "" : "span 2" }}>
-        {props.title}
-      </th>
+      <th class={props.children ? "" : "col-span-2"}>{props.title}</th>
       <Show when={props.children}>
         <td>{props.children}</td>
       </Show>


### PR DESCRIPTION
Addresses #366; we are not getting around inline styles, as both `@tanstack/solid-virtual` (all virtualized scrolling lists) and `@kobalte/core`(tooltips) require them; includes CSP settings to allow for fathom. Some of the other settings seem to have been previously fixed, but never deployed.