### PR TITLE
fix: update dependency versions for ubuntu-latest

### DIFF
--- a/.github/workflows/ci-v1.yml
+++ b/.github/workflows/ci-v1.yml
@@ -36,7 +36,7 @@ jobs:
     name: Rust ${{matrix.rust}}
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +60,7 @@ jobs:
     name: Rust MSRV
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
@@ -93,7 +93,7 @@ jobs:
 
   rustfmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
@@ -105,7 +105,7 @@ jobs:
       - run: cargo fmt --manifest-path crates/v1/Cargo.toml -- --check
 
   check-licenses:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Check Rust Licenses
@@ -115,7 +115,7 @@ jobs:
 
 #  outdated:
 #     name: Outdated
-#     runs-on: ubuntu-latest
+#     runs-on: ubuntu-22.04
 #     if: github.event_name != 'pull_request'
 #     timeout-minutes: 45
 #     steps:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,8 +14,32 @@ on:
       - main
 
 jobs:
-  release-plz:
-    name: Release-plz
+  release-plz-v1:
+    name: Release-plz-v1
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: install native dependecies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.0-dev
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run release-plz (devtools for Tauri v1)
+        uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          project_manifest: crates/v1/crates/devtools/Cargo.toml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+  release-plz-v2:
+    name: Release-plz-v2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -27,18 +51,10 @@ jobs:
       - name: install native dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev webkit2gtk-4.1
+          sudo apt-get install -y libwebkit2gtk-4.1-dev
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run release-plz (devtools for Tauri v1)
-        uses: MarcoIeni/release-plz-action@v0.5
-        with:
-          project_manifest: crates/v1/crates/devtools/Cargo.toml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-
-      - name: Run release-plz
+      - name: Run release-plz (devtools for Tauri v2)
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The live rollout fails because the github workflow still targets an older version of ubuntu, so the required package libwebkit2gtk-4.0-dev is no longer available, since it got updated to libwebkit2gtk-4.1-dev.