### PR TITLE
chore(ci): general CI review and refresh

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @crabnebula-dev/maintainers

--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -1,11 +1,15 @@
 name: JS checks
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - ".github/workflows/js-checks.yml"
       - "clients/web/**"
       - "examples/**"
+      - "**/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,8 +1,4 @@
-name: Release-plz
-
-permissions:
-  pull-requests: write
-  contents: write
+name: release-plz
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,23 +11,25 @@ on:
 
 jobs:
   release-plz-v1:
-    name: Release-plz-v1
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: install native dependecies
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev
       - uses: Swatinem/rust-cache@v2
-
       - name: Run release-plz (devtools for Tauri v1)
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
         with:
           project_manifest: crates/v1/crates/devtools/Cargo.toml
         env:
@@ -39,23 +37,25 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   release-plz-v2:
-    name: Release-plz-v2
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: install native dependecies
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev
       - uses: Swatinem/rust-cache@v2
-
       - name: Run release-plz (devtools for Tauri v2)
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -33,11 +33,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ nightly, stable ]
+        rust: [nightly, stable]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - name: install native dependecies
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev protobuf-compiler
@@ -56,7 +58,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: install native dependecies
         run: |
           sudo apt-get update
@@ -78,7 +82,9 @@ jobs:
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: install native dependecies
         run: |
           sudo apt-get update
@@ -95,7 +101,9 @@ jobs:
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install rustfmt with nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -105,7 +113,9 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Check Cargo Deny (crates/v1)
         uses: EmbarkStudios/cargo-deny-action@v2
         with:

--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -22,13 +22,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pre_ci:
-    uses: dtolnay/.github/.github/workflows/pre_ci.yml@master
-
   test:
     name: Rust ${{matrix.rust}}
-    needs: pre_ci
-    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -53,8 +48,6 @@ jobs:
 
   msrv:
     name: Rust MSRV
-    needs: pre_ci
-    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
@@ -79,7 +72,6 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
@@ -98,7 +90,6 @@ jobs:
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -100,6 +100,7 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --manifest-path crates/v1/Cargo.toml -- --check
+      - run: cargo fmt --manifest-path examples/tauri-v1/Cargo.toml -- --check
 
   cargo-deny:
     runs-on: ubuntu-22.04

--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -1,17 +1,14 @@
-name: CI
+name: RS checks (v1)
 
 on:
   push:
-    paths:
-      - ".github/workflows/ci.yml"
-      - "crates/**/*.rs"
-      - "crates/wire/proto/*.proto"
-      - "**/Cargo.toml"
+    branches:
+      - main
   pull_request:
     paths:
-      - ".github/workflows/ci.yml"
-      - "crates/**/*.rs"
-      - "crates/wire/proto/*.proto"
+      - ".github/workflows/rs-checks-v1.yml"
+      - "**/*.rs"
+      - "**/*.proto"
       - "**/Cargo.toml"
 
 permissions:
@@ -32,7 +29,7 @@ jobs:
     name: Rust ${{matrix.rust}}
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -43,12 +40,12 @@ jobs:
       - name: install native dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y webkit2gtk-4.1 protobuf-compiler
+          sudo apt-get install -y libwebkit2gtk-4.0-dev protobuf-compiler
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      - run: cargo test --manifest-path crates/v1/Cargo.toml
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
@@ -56,28 +53,28 @@ jobs:
     name: Rust MSRV
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: install native dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y webkit2gtk-4.1 protobuf-compiler
+          sudo apt-get install -y libwebkit2gtk-4.0-dev protobuf-compiler
       - id: msrv
         name: Find out the MSRV from Cargo.toml
         run: |
-          msrv=$(yq -e '.workspace.package.rust-version' ./Cargo.toml);
+          msrv=$(yq -e '.package.rust-version' ./crates/v1/crates/devtools/Cargo.toml);
           echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --workspace --tests
+      - run: cargo check --manifest-path crates/v1/Cargo.toml --tests
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
@@ -85,16 +82,16 @@ jobs:
       - name: install native dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y webkit2gtk-4.1
+          sudo apt-get install -y libwebkit2gtk-4.0-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace -- -Dclippy::all -Dclippy::pedantic
+      - run: cargo clippy --manifest-path crates/v1/Cargo.toml -- -Dclippy::all -Dclippy::pedantic
 
   rustfmt:
     name: Rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
@@ -103,21 +100,17 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --all -- --check
+      - run: cargo fmt --manifest-path crates/v1/Cargo.toml -- --check
 
   cargo-deny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Check Rust Code
+      - name: Check Cargo Deny (crates/v1)
         uses: EmbarkStudios/cargo-deny-action@v2
-
-#  outdated:
-#     name: Outdated
-#     runs-on: ubuntu-latest
-#     if: github.event_name != 'pull_request'
-#     timeout-minutes: 45
-#     steps:
-#       - uses: actions/checkout@v3
-#       - uses: dtolnay/install@cargo-outdated
-#       - run: cargo outdated --workspace --exit-code 1
+        with:
+          manifest-path: crates/v1/Cargo.toml
+      - name: Check Cargo Deny (examples/tauri-v1)
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          manifest-path: examples/tauri-v1/Cargo.toml

--- a/.github/workflows/rs-checks-v2.yml
+++ b/.github/workflows/rs-checks-v2.yml
@@ -33,10 +33,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [ nightly, stable ]
+        rust: [nightly, stable]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: install native dependecies
         run: |
           sudo apt-get update
@@ -56,7 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: install native dependecies
         run: |
           sudo apt-get update
@@ -78,7 +82,9 @@ jobs:
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: install native dependecies
         run: |
           sudo apt-get update
@@ -95,7 +101,9 @@ jobs:
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install rustfmt with nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -105,16 +113,8 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Check Rust Code
         uses: EmbarkStudios/cargo-deny-action@v2
-
-#  outdated:
-#     name: Outdated
-#     runs-on: ubuntu-latest
-#     if: github.event_name != 'pull_request'
-#     timeout-minutes: 45
-#     steps:
-#       - uses: actions/checkout@v3
-#       - uses: dtolnay/install@cargo-outdated
-#       - run: cargo outdated --workspace --exit-code 1

--- a/.github/workflows/rs-checks-v2.yml
+++ b/.github/workflows/rs-checks-v2.yml
@@ -22,13 +22,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pre_ci:
-    uses: dtolnay/.github/.github/workflows/pre_ci.yml@master
-
   test:
     name: Rust ${{matrix.rust}}
-    needs: pre_ci
-    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -53,8 +48,6 @@ jobs:
 
   msrv:
     name: Rust MSRV
-    needs: pre_ci
-    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -79,7 +72,6 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
@@ -98,7 +90,6 @@ jobs:
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/rs-checks-v2.yml
+++ b/.github/workflows/rs-checks-v2.yml
@@ -1,21 +1,14 @@
-name: CI (v1)
+name: RS checks (v2)
 
 on:
   push:
-    paths:
-      - ".github/workflows/ci.yml"
-      - "crates/**/*.rs"
-      - "!crates/devtools/**/*.rs"
-      - "crates/v1/**/*.rs"
-      - "crates/wire/proto/*.proto"
-      - "**/Cargo.toml"
+    branches:
+      - main
   pull_request:
     paths:
-      - ".github/workflows/ci.yml"
-      - "crates/**/*.rs"
-      - "!crates/devtools/**/*.rs"
-      - "crates/v1/**/*.rs"
-      - "crates/wire/proto/*.proto"
+      - ".github/workflows/rs-checks-v2.yml"
+      - "**/*.rs"
+      - "**/*.proto"
       - "**/Cargo.toml"
 
 permissions:
@@ -36,7 +29,7 @@ jobs:
     name: Rust ${{matrix.rust}}
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -47,12 +40,12 @@ jobs:
       - name: install native dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev protobuf-compiler
+          sudo apt-get install -y webkit2gtk-4.1 protobuf-compiler
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --manifest-path crates/v1/Cargo.toml
+      - run: cargo test --workspace
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
 
@@ -60,28 +53,28 @@ jobs:
     name: Rust MSRV
     needs: pre_ci
     if: needs.pre_ci.outputs.continue
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - name: install native dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev protobuf-compiler
+          sudo apt-get install -y webkit2gtk-4.1 protobuf-compiler
       - id: msrv
         name: Find out the MSRV from Cargo.toml
         run: |
-          msrv=$(yq -e '.package.rust-version' ./crates/v1/crates/devtools/Cargo.toml);
+          msrv=$(yq -e '.workspace.package.rust-version' ./Cargo.toml);
           echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --manifest-path crates/v1/Cargo.toml --tests
+      - run: cargo check --workspace --tests
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
@@ -89,16 +82,16 @@ jobs:
       - name: install native dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev
+          sudo apt-get install -y webkit2gtk-4.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --manifest-path crates/v1/Cargo.toml -- -Dclippy::all -Dclippy::pedantic
+      - run: cargo clippy --workspace -- -Dclippy::all -Dclippy::pedantic
 
   rustfmt:
     name: Rustfmt
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
     steps:
@@ -107,24 +100,18 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - run: cargo fmt --manifest-path crates/v1/Cargo.toml -- --check
+      - run: cargo fmt --all -- --check
 
   cargo-deny:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check Cargo Deny (crates/v1)
+      - name: Check Rust Code
         uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          manifest-path: crates/v1/Cargo.toml
-      - name: Check Cargo Deny (examples/tauri-v1)
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          manifest-path: examples/tauri-v1/Cargo.toml
 
 #  outdated:
 #     name: Outdated
-#     runs-on: ubuntu-22.04
+#     runs-on: ubuntu-latest
 #     if: github.event_name != 'pull_request'
 #     timeout-minutes: 45
 #     steps:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Spell Check Repo
-        uses: crate-ci/typos@v1.19.0
+        uses: crate-ci/typos@v1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-*.ts    @atila-crabnebula @tejas-crabnebula @johann-crabnebula
-*.tsx   @atila-crabnebula @tejas-crabnebula @johann-crabnebula
-*.astro   @atila-crabnebula @tejas-crabnebula @johann-crabnebula
-*.rs    @lucasfernog-crabnebula @david-crabnebula @CrabNejonas

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:base", ":disableDependencyDashboard"],
+  extends: ["config:base", ":disableDependencyDashboard", "helpers:pinGitHubActionDigests"],
 
   // run Renovate bot once a month
   schedule: ["* * 1 * *"],


### PR DESCRIPTION
Run clippy and rustfmt on PRs! :laughing:
Removed the `pre_ci` dependency for simpler filters.
Updated codeowners.
Version updates, minor renaming.

Renovate config should create PRs for changing actions to pinned hashes.