### PR TITLE
chore: pinning rust-toolchain should use master + with.toolchain option

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
       - name: install native dependencies
         run: |
           sudo apt-get update
@@ -47,8 +48,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
       - name: install native dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: install native dependecies
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev protobuf-compiler
@@ -63,7 +63,7 @@ jobs:
         run: |
           msrv=$(yq -e '.package.rust-version' ./crates/v1/crates/devtools/Cargo.toml);
           echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -77,12 +77,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: install native dependecies
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.0-dev
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo clippy --manifest-path crates/v1/Cargo.toml -- -Dclippy::all -Dclippy::pedantic
@@ -96,8 +97,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rustfmt with nightly toolchain
-        uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: nightly
           components: rustfmt
       - run: cargo fmt --manifest-path crates/v1/Cargo.toml -- --check
       - run: cargo fmt --manifest-path examples/tauri-v1/Cargo.toml -- --check

--- a/.github/workflows/rs-checks-v2.yml
+++ b/.github/workflows/rs-checks-v2.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: install native dependecies
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.1 protobuf-compiler
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: install native dependecies
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.1 protobuf-compiler
@@ -63,7 +63,7 @@ jobs:
         run: |
           msrv=$(yq -e '.workspace.package.rust-version' ./Cargo.toml);
           echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
@@ -77,12 +77,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: install native dependecies
+      - name: install native dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.1
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo clippy --workspace -- -Dclippy::all -Dclippy::pedantic
@@ -96,8 +97,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install rustfmt with nightly toolchain
-        uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: nightly
           components: rustfmt
       - run: cargo fmt --all -- --check
 


### PR DESCRIPTION
In https://github.com/crabnebula-dev/devtools/pull/403 the actions are pinned.

However https://github.com/dtolnay/rust-toolchain#choice-of-full-length-commit-sha does something interesting with it's version tags to infer the rust version you want from it. This follows the recommendation of using the latest master sha and providing an explicit `with.toolchain` argument instead.