### PR TITLE
chore: remove unused crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,6 @@ dependencies = [
 name = "devtools-core"
 version = "0.3.6"
 dependencies = [
- "async-stream",
  "bytes",
  "devtools-wire-format",
  "futures",
@@ -747,10 +746,8 @@ version = "0.5.3"
 dependencies = [
  "bitflags 2.13.1",
  "prost",
- "prost-build",
  "prost-types",
  "tonic",
- "tonic-build",
  "tonic-prost",
  "tracing-core",
 ]

--- a/crates/devtools-core/Cargo.toml
+++ b/crates/devtools-core/Cargo.toml
@@ -25,7 +25,6 @@ tower-layer = "0.3"
 futures = "0.3.30"
 bytes = "1.7.1"
 ringbuf = "0.4.4"
-async-stream = "0.3.5"
 http = "1"
 log = "0.4"
 

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -17,7 +17,3 @@ tonic-prost.workspace = true
 prost-types.workspace = true
 tracing-core.workspace = true
 bitflags = "2.6"
-
-[dev-dependencies]
-tonic-build = "0.14"
-prost-build = "0.14"


### PR DESCRIPTION
According to cargo-udeps.

The wire build deps make sense since that was migrated to the separate crate to build protobufs.
async-stream must have been around for a while.