### PR TITLE
chore: update MSRV policy & resolver v3

### DIFF
--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -69,6 +69,8 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: crates/v1
       - run: |
           rm crates/v1/Cargo.lock
           cargo check --manifest-path crates/v1/Cargo.toml

--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -67,7 +67,9 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: cargo check --manifest-path crates/v1/Cargo.toml --tests
+      - run: |
+          rm crates/v1/Cargo.lock
+          cargo check --manifest-path crates/v1/Cargo.toml
 
   clippy:
     name: Clippy

--- a/.github/workflows/rs-checks-v1.yml
+++ b/.github/workflows/rs-checks-v1.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           toolchain: ${{matrix.rust}}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: crates/v1
       - run: cargo test --manifest-path crates/v1/Cargo.toml
         env:
           RUSTFLAGS: ${{matrix.rustflags}} ${{env.RUSTFLAGS}}
@@ -88,6 +90,8 @@ jobs:
           toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: crates/v1
       - run: cargo clippy --manifest-path crates/v1/Cargo.toml -- -Dclippy::all -Dclippy::pedantic
 
   rustfmt:

--- a/.github/workflows/rs-checks-v2.yml
+++ b/.github/workflows/rs-checks-v2.yml
@@ -67,7 +67,9 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.msrv }}
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      - run: cargo check --workspace --tests
+      - run: |
+          rm Cargo.lock
+          cargo check --workspace
 
   clippy:
     name: Clippy

--- a/.github/workflows/rs-checks-v2.yml
+++ b/.github/workflows/rs-checks-v2.yml
@@ -61,7 +61,7 @@ jobs:
       - id: msrv
         name: Find out the MSRV from Cargo.toml
         run: |
-          msrv=$(yq -e '.workspace.package.rust-version' ./Cargo.toml);
+          msrv=$(yq -e '.package.rust-version' ./crates/devtools/Cargo.toml);
           echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "crates/devtools-core",
     "crates/devtools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ exclude = ["crates/v1", "crates/devtools", "examples/tauri-v1"]
 [workspace.package]
 authors = ["CrabNebula <hello@crabnebula.dev>"]
 edition = "2021"
-rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabnebula-dev/devtools"
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -14,10 +14,10 @@ To compile the project and run tests, you must have the **Protocol Buffers compi
 
 ### Installation
 
-*   **macOS**: `brew install protobuf`
-*   **Ubuntu/Debian**: `sudo apt install -y protobuf-compiler`
-*   **Windows (Chocolatey)**: `choco install protoc`
-*   **Other**: Download from [GitHub Releases](https://github.com/protocolbuffers/protobuf/releases)
+- **macOS**: `brew install protobuf`
+- **Ubuntu/Debian**: `sudo apt install -y protobuf-compiler`
+- **Windows (Chocolatey)**: `choco install protoc`
+- **Other**: Download from [GitHub Releases](https://github.com/protocolbuffers/protobuf/releases)
 
 Ensure `protoc` is in your `PATH`. You can verify by running `protoc --version`.
 
@@ -55,6 +55,18 @@ Running tests would also generate the new code, but fail until the changes are c
 ```bash
 cargo test -p devtools-wire-format-build
 ```
+
+## MSRV policy
+
+Each crate's `rust-version` covers its **default features**, resolved with [`resolver = "3"`](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions).
+Optional features may require a newer toolchain; that requirement is not part of the guarantee.
+
+MSRV is raised only when a default-feature dependency forces it and dependencies are not held back to avoid it.
+An MSRV increase is not a breaking change and may land in any release, including a patch.
+
+The resolver is chosen by your own workspace or top-level crate, not by this one.
+Typically this is the crate in `src-tauri` or the workspace the Tauri application is in.
+Using `resolver = "3"` is highly encouraged. Otherwise it's up to the user to pin dependencies to support the Rust version you have access to.
 
 # Architecture
 

--- a/crates/devtools-core/Cargo.toml
+++ b/crates/devtools-core/Cargo.toml
@@ -2,9 +2,9 @@
 name = "devtools-core"
 version = "0.3.6"
 description = "CrabNebula devtools for Tauri: Inspect, monitor, and understand your application with ease."
+rust-version = "1.85.0"
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -2,9 +2,9 @@
 name = "tauri-plugin-devtools"
 version = "2.1.0"
 description = "CrabNebula devtools for Tauri: Inspect, monitor, and understand your application with ease."
+rust-version = "1.85.0"
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 links = "tauri-plugin-devtools"

--- a/crates/v1/Cargo.toml
+++ b/crates/v1/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["crates/*"]

--- a/crates/v1/crates/devtools/Cargo.toml
+++ b/crates/v1/crates/devtools/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["CrabNebula <hello@crabnebula.dev>"]
 edition = "2021"
 version = "0.3.4"
 description = "CrabNebula devtools for Tauri: Inspect, monitor, and understand your application with ease."
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabnebula-dev/devtools"
 

--- a/crates/v1/crates/devtools/Cargo.toml
+++ b/crates/v1/crates/devtools/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["CrabNebula <hello@crabnebula.dev>"]
 edition = "2021"
 version = "0.3.4"
 description = "CrabNebula devtools for Tauri: Inspect, monitor, and understand your application with ease."
-rust-version = "1.88.0"
+rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/crabnebula-dev/devtools"
 

--- a/crates/wire-build/Cargo.toml
+++ b/crates/wire-build/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "devtools-wire-format-build"
 version = "0.1.0"
+rust-version = "1.85.0"
 license.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -2,9 +2,9 @@
 name = "devtools-wire-format"
 version = "0.5.3"
 description = "gRPC wire format for the CrabNebula devtools for Tauri"
+rust-version = "1.85.0"
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 


### PR DESCRIPTION
Because the MSRV already needs to be 1.85+ the v3 resolver should be available.
We didn't have a policy on devtools before, while it does have the rust side of the plugin.

Today this means the next release will end up higher MSRV than what Tauri v2 promises, however it should be more relaxed than what the upcoming Tauri v3 is looking at.

The caveat about *default features* is a bit unnecessary on devtools right now, because there's no real feature flags to choose from. Just `wry` being used by default with no alternatives yet.

Particular MSRV requirements.
The v2 workspace requires `1.85.0` because it's the first one that stabilizes `edition2024` used by dependencies.
The v1 workspace requires `1.88.0` because the v3 resolver selects `ignore 0.4.30` which actually uses `1.88.0` syntax but does not declare it in metadata. Meaning we'd violate the policy where using the v3 resolver should work unless we declare at least `1.88.0` as well.