### PR TITLE
chore: release devtools 0.3.5

### DIFF
--- a/crates/v1/Cargo.lock
+++ b/crates/v1/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "devtools"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-stream",
  "bytes",

--- a/crates/v1/crates/devtools/CHANGELOG.md
+++ b/crates/v1/crates/devtools/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/crabnebula-dev/devtools/compare/v0.3.4...v0.3.5) - 2026-09-11
+
+### Changed
+
+- MSRV bump to 1.88, general dependency upgrades, ci chores ([#381](https://github.com/crabnebula-dev/devtools/pull/381))
+- Added MSRV policy ([#414](https://github.com/crabnebula-dev/devtools/pull/414))
+- Update to devtools-core 0.4.0 ([#418](https://github.com/crabnebula-dev/devtools/pull/418))
+- Upgrade to tonic/prost 0.14 and http 1 ([#407](https://github.com/crabnebula-dev/devtools/pull/407))
+- Simplified CORS handling to mirror the allowed request origin in `Access-Control-Allow-Origin`, including in local development mode, instead of returning an origin list or `*`. ([#407](https://github.com/crabnebula-dev/devtools/pull/407))
+
+### Fixed
+
+- Increase span buffer size to avoid dropped spans and UX issues. ([#227](https://github.com/crabnebula-dev/devtools/pull/227))
+- Fix v1 release note duplication
+
+### Other
+
+- Address clippy errors ([#401](https://github.com/crabnebula-dev/devtools/pull/401))
+- General dependency updates
+- General CI maintenance
+
 ## [0.3.4](https://github.com/crabnebula-dev/devtools/compare/v0.3.3...v0.3.4) - 2025-08-05
 
 ### Other
@@ -17,9 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.3](https://github.com/crabnebula-dev/devtools/compare/v0.3.2...v0.3.3) - 2024-07-25
 
 ### Fixed
+
 - use correct rust syntax for cfg on expressions ([#314](https://github.com/crabnebula-dev/devtools/pull/314))
 
 ## [0.3.2](https://github.com/crabnebula-dev/devtools/compare/v0.3.1...v0.3.2) - 2024-05-29
 
 ### Fixed
+
 - Fixed CORS issues

--- a/crates/v1/crates/devtools/CHANGELOG.md
+++ b/crates/v1/crates/devtools/CHANGELOG.md
@@ -11,16 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- 3033
-- change default port to 3030
+- change default port to 3030 ([#373](https://github.com/crabnebula-dev/devtools/pull/373))
 - bump msrv
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## [0.3.3](https://github.com/crabnebula-dev/devtools/compare/v0.3.2...v0.3.3) - 2024-07-25
 

--- a/crates/v1/crates/devtools/Cargo.toml
+++ b/crates/v1/crates/devtools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "devtools"
 authors = ["CrabNebula <hello@crabnebula.dev>"]
 edition = "2021"
-version = "0.3.4"
+version = "0.3.5"
 description = "CrabNebula devtools for Tauri: Inspect, monitor, and understand your application with ease."
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## :person_bald: New release

* `devtools`: 0.3.4 -> 0.3.5 (✓ API compatible changes*)

## Notes

Manually generated and reviewed release, because `devtools-core 0.3.7` currently exists and causes a CI to fail on release PR generation.

*=Regarding API compatibility, I found technically we re-export the `devtools_core::Error` type, which exposes a Tonic error variant. If you're using your own import of `tonic 0.10.x` and were comparing / matching against this it may now be different types.

This was true as well of the `tauri-plugin-devtools 2.2.0` and `2.2.1` releases. This isn't considered breaking by the `cargo-semver-checks` that CI normally does.