### PR TITLE
chore: release devtools-core 0.4.0 and tauri-plugin-devtools 2.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-devtools"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-stream",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "devtools-core"
-version = "0.3.7"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "devtools-wire-format",

--- a/crates/devtools-core/CHANGELOG.md
+++ b/crates/devtools-core/CHANGELOG.md
@@ -30,6 +30,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - General dependency updates
 - General CI maintenance
 
+## [0.3.7](https://github.com/crabnebula-dev/devtools/compare/devtools-core-v0.3.6...devtools-core-v0.3.7) - 2026-09-11
+
+### Added
+
+- Add the opt-in `test-utils` feature, exposing `ServerHandle::reset_defaults` to reset allowed origins for testing production and development modes. ([#402](https://github.com/crabnebula-dev/devtools/pull/402))
+
+### Changed
+
+- Raise MSRV to 1.85. Added MSRV policy ([#414](https://github.com/crabnebula-dev/devtools/pull/414))
+- Upgrade to tonic/prost 0.14 and http 1. ([#407](https://github.com/crabnebula-dev/devtools/pull/407))
+- Simplified CORS handling to mirror the allowed request origin in `Access-Control-Allow-Origin`, including in local development mode, instead of returning an origin list or `*`. ([#407](https://github.com/crabnebula-dev/devtools/pull/407))
+- Remove the unused `async-stream` dependency. ([#413](https://github.com/crabnebula-dev/devtools/pull/413))
+
+### Fixed
+
+- Increase span buffer size to avoid dropped spans and UX issues. ([#227](https://github.com/crabnebula-dev/devtools/pull/227))
+
+### Other
+
+- General dependency updates
+- General CI maintenance
+
 ## [0.3.6](https://github.com/crabnebula-dev/devtools/compare/devtools-core-v0.3.5...devtools-core-v0.3.6) - 2025-08-05
 
 ### Other

--- a/crates/devtools-core/CHANGELOG.md
+++ b/crates/devtools-core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.7](https://github.com/crabnebula-dev/devtools/compare/devtools-core-v0.3.6...devtools-core-v0.3.7) - 2026-09-11
+## [0.4.0](https://github.com/crabnebula-dev/devtools/compare/devtools-core-v0.3.6...devtools-core-v0.4.0) - 2026-09-11
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- BREAKING: updated `devtools-wire-format` to `0.6.0` including a breaking version upgrade of tonic/prost types.
 - Raise MSRV to 1.85. Added MSRV policy ([#414](https://github.com/crabnebula-dev/devtools/pull/414))
 - Upgrade to tonic/prost 0.14 and http 1. ([#407](https://github.com/crabnebula-dev/devtools/pull/407))
 - Simplified CORS handling to mirror the allowed request origin in `Access-Control-Allow-Origin`, including in local development mode, instead of returning an origin list or `*`. ([#407](https://github.com/crabnebula-dev/devtools/pull/407))

--- a/crates/devtools-core/Cargo.toml
+++ b/crates/devtools-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devtools-core"
-version = "0.3.7"
+version = "0.4.0"
 description = "CrabNebula devtools for Tauri: Inspect, monitor, and understand your application with ease."
 rust-version = "1.85.0"
 authors.workspace = true

--- a/crates/devtools/CHANGELOG.md
+++ b/crates/devtools/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1](https://github.com/crabnebula-dev/devtools/compare/tauri-plugin-devtools-v2.2.0...tauri-plugin-devtools-v2.2.1) - 2026-09-11
+
+### Fixed
+
+- `devtools-core` release should have been breaking, upgrade to `0.4.0`.
+
 ## [2.2.0](https://github.com/crabnebula-dev/devtools/compare/tauri-plugin-devtools-v2.1.0...tauri-plugin-devtools-v2.2.0) - 2026-09-11
 
 ### Changed

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -23,10 +23,10 @@ tauri = { workspace = true, features = ["test"] }
 reqwest = { version = "0.13.2", default-features = false, features = [
     "rustls",
 ] }
-devtools-core = { path = "../devtools-core", version = "0.3.7", features = ["test-utils"] }
+devtools-core = { path = "../devtools-core", version = "0.4.0", features = ["test-utils"] }
 
 [dependencies]
-devtools-core = { path = "../devtools-core", version = "0.3.7" }
+devtools-core = { path = "../devtools-core", version = "0.4.0" }
 tauri.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-devtools"
-version = "2.2.0"
+version = "2.2.1"
 description = "CrabNebula devtools for Tauri: Inspect, monitor, and understand your application with ease."
 rust-version = "1.85.0"
 authors.workspace = true

--- a/crates/v1/Cargo.lock
+++ b/crates/v1/Cargo.lock
@@ -665,9 +665,8 @@ dependencies = [
 
 [[package]]
 name = "devtools-core"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
- "async-stream",
  "bytes",
  "devtools-wire-format",
  "futures",
@@ -690,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "devtools-wire-format"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.11.0",
  "prost",

--- a/crates/v1/crates/devtools/Cargo.toml
+++ b/crates/v1/crates/devtools/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/crabnebula-dev/devtools"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-devtools-core = { path = "../../../devtools-core", version = "0.3.3" }
+devtools-core = { path = "../../../devtools-core", version = "0.4.0" }
 tauri = { version = "1.6.1", features = ["tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/tauri/src-tauri/Cargo.toml
+++ b/examples/tauri/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build.workspace = true
 
 [dependencies]
 tauri.workspace = true
-tauri-plugin-devtools = { path = "../../../crates/devtools", version = "2.2.0" }
+tauri-plugin-devtools = { path = "../../../crates/devtools", version = "2.2.1" }
 tracing.workspace = true
 tokio = { workspace = true, features = ["time"] }
 reqwest = { version = "0.13.2", default-features = false, features = [


### PR DESCRIPTION
The previous update to `devtools-core 0.3.7` should have been a breaking change because it re-exports the breaking changes from `devtools-wire-format 0.6.0` causing mixed types when doing `devtools-core ^0.3.6` updates.

This is mitigation step 1 of 2:
- Release new crates with the correct version bumps.
- Yank the `devtools-core 0.3.7` crate version.